### PR TITLE
feat(game): add randomized 3D level transition animations and optimiz…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "explorer.fileNesting.expand": false,
   "explorer.fileNesting.patterns": {
     "*.ts": "$(capture).spec.ts, $(capture).html, $(capture).scss, $(capture).css"
-  }
+  },
+  "cSpell.words": ["mult"]
 }

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -12,8 +12,7 @@
 
   @media screen and (min-width: $default-app-width) {
     background-image:
-      radial-gradient(ellipse at center, rgba(15, 15, 15, 0.25) 0%, rgba(0, 0, 0, 0.82) 100%),
-      url('/RikkleBacker.webp');
+      radial-gradient(ellipse at center, rgba(15, 15, 15, 0.25) 0%, rgba(0, 0, 0, 0.82) 100%), url('/RikkleBacker.webp');
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;

--- a/src/app/game/components/dialogs/components/level-complete/level-complete.scss
+++ b/src/app/game/components/dialogs/components/level-complete/level-complete.scss
@@ -64,5 +64,3 @@
     margin-bottom: 0.25em;
   }
 }
-
-

--- a/src/app/game/components/game-container/game-container.html
+++ b/src/app/game/components/game-container/game-container.html
@@ -39,4 +39,3 @@
     &copy; {{ copyrightYear }} David Teply
   </div>
 </div>
-

--- a/src/app/game/components/game-container/game-container.scss
+++ b/src/app/game/components/game-container/game-container.scss
@@ -265,4 +265,3 @@
     bottom: max(1.5em, env(safe-area-inset-bottom));
   }
 }
-

--- a/src/app/game/models/game-piece/game-piece.ts
+++ b/src/app/game/models/game-piece/game-piece.ts
@@ -18,6 +18,7 @@ import { PowerMove } from './power-move';
 import { PieceMaterials, PieceSideMaterial } from '../../services/material/material-models';
 import { LevelGeometryType } from '../../level-geometry-type';
 import { GamePieceRemovalStyle } from './game-piece-removal-style';
+import { LevelAnimationStyle } from '../level-animation-style';
 
 export class GamePiece extends Object3D {
   private _geometryCube: BoxGeometry;
@@ -150,6 +151,7 @@ export class GamePiece extends Object3D {
 
   public Reset(levelGeometryType: LevelGeometryType): void {
     this._removeTween?.stop();
+    this._levelChangeTween?.stop();
     this._isRemoved = false;
 
     // set geometry type and set normalized access variable
@@ -213,15 +215,167 @@ export class GamePiece extends Object3D {
     this._matchKey = this._pieceMaterials[this._matchKeySequence[0]]?.matchKey;
   }
 
-  public AnimateLevelChangeTween(start: boolean): void {
+  public AnimateLevelChangeTween(
+    start: boolean,
+    style: LevelAnimationStyle = LevelAnimationStyle.RadialAssemble,
+    delayOffset = 0,
+  ): void {
     this._levelChangeTween?.stop();
 
-    const delta = start ? { o: 0.0 } : { o: 1.0 };
-    const target = start ? { o: 1.0 } : { o: 0.0 };
+    const rad = this._thetaStart;
+    const dirX = Math.cos(rad);
+    const dirZ = Math.sin(rad);
+
+    let startX = 0;
+    let startY = 0;
+    let startZ = 0;
+    let startRotX = 0;
+    let startRotY = 0;
+    let startRotZ = 0;
+    let startScaleX = 1;
+    let startScaleY = 1;
+    let startScaleZ = 1;
+
+    let targetX = 0;
+    let targetY = 0;
+    let targetZ = 0;
+    let targetRotX = 0;
+    let targetRotY = 0;
+    let targetRotZ = 0;
+    let targetScaleX = 1;
+    let targetScaleY = 1;
+    let targetScaleZ = 1;
+
+    let easingFunc = start ? Easing.Sinusoidal.Out : Easing.Sinusoidal.In;
+
+    switch (style) {
+      case LevelAnimationStyle.RadialAssemble: {
+        const mult = start ? MathUtils.randFloat(6.0, 11.0) : MathUtils.randFloat(8.0, 15.0);
+        const yOff = MathUtils.randFloat(-5.0, 5.0);
+        if (start) {
+          startX = dirX * mult;
+          startZ = dirZ * mult;
+          startY = yOff;
+          startRotX = MathUtils.randFloat(-Math.PI * 2, Math.PI * 2);
+          startRotY = MathUtils.randFloat(-Math.PI * 2, Math.PI * 2);
+          startRotZ = MathUtils.randFloat(-Math.PI, Math.PI);
+          startScaleX = startScaleY = startScaleZ = 0.05;
+          easingFunc = Easing.Back.Out;
+        } else {
+          targetX = dirX * mult;
+          targetZ = dirZ * mult;
+          targetY = yOff;
+          targetRotX = MathUtils.randFloat(-Math.PI * 2, Math.PI * 2);
+          targetRotY = MathUtils.randFloat(-Math.PI * 2, Math.PI * 2);
+          targetScaleX = targetScaleY = targetScaleZ = 0.0;
+          easingFunc = Easing.Quadratic.In;
+        }
+        break;
+      }
+      case LevelAnimationStyle.SpiralVortex: {
+        const radius = MathUtils.randFloat(6.0, 10.0);
+        const altY = MathUtils.randFloat(8.0, 15.0) * (MathUtils.randInt(0, 1) ? 1 : -1);
+        if (start) {
+          startX = dirX * radius + dirZ * 3.0;
+          startZ = dirZ * radius - dirX * 3.0;
+          startY = altY;
+          startRotY = Math.PI * 6;
+          startScaleX = startScaleY = startScaleZ = 0.05;
+          easingFunc = Easing.Cubic.Out;
+        } else {
+          targetX = dirX * radius - dirZ * 4.0;
+          targetZ = dirZ * radius + dirX * 4.0;
+          targetY = altY * -1;
+          targetRotY = -Math.PI * 6;
+          targetScaleX = targetScaleY = targetScaleZ = 0.0;
+          easingFunc = Easing.Cubic.In;
+        }
+        break;
+      }
+      case LevelAnimationStyle.ScatterSnap: {
+        if (start) {
+          startX = MathUtils.randFloat(-12, 12);
+          startY = MathUtils.randFloat(-12, 12);
+          startZ = MathUtils.randFloat(-12, 12);
+          startRotX = MathUtils.randFloat(-Math.PI * 3, Math.PI * 3);
+          startRotY = MathUtils.randFloat(-Math.PI * 3, Math.PI * 3);
+          startRotZ = MathUtils.randFloat(-Math.PI * 3, Math.PI * 3);
+          startScaleX = startScaleY = startScaleZ = 0.02;
+          easingFunc = Easing.Exponential.Out;
+        } else {
+          targetX = MathUtils.randFloat(-15, 15);
+          targetY = MathUtils.randFloat(-15, 15);
+          targetZ = MathUtils.randFloat(-15, 15);
+          targetRotX = MathUtils.randFloat(-Math.PI * 3, Math.PI * 3);
+          targetRotY = MathUtils.randFloat(-Math.PI * 3, Math.PI * 3);
+          targetRotZ = MathUtils.randFloat(-Math.PI * 3, Math.PI * 3);
+          targetScaleX = targetScaleY = targetScaleZ = 0.0;
+          easingFunc = Easing.Exponential.In;
+        }
+        break;
+      }
+      case LevelAnimationStyle.CascadeWave: {
+        const xDist = MathUtils.randFloat(3.5, 4.5) * (MathUtils.randInt(0, 1) ? 1 : -1);
+        if (start) {
+          startX = xDist;
+          startZ = dirZ * MathUtils.randFloat(1.5, 3.0);
+          startY = MathUtils.randFloat(-0.8, 0.8);
+          startScaleX = 1.35;
+          startScaleY = startScaleZ = 0.85;
+          startRotZ = MathUtils.randFloat(-0.25, 0.25);
+          easingFunc = Easing.Bounce.Out;
+        } else {
+          targetX = -xDist * 1.5;
+          targetZ = dirZ * MathUtils.randFloat(2.0, 4.5);
+          targetScaleX = 0.1;
+          targetScaleY = targetScaleZ = 0.1;
+          targetRotZ = MathUtils.randFloat(-0.3, 0.3);
+          easingFunc = Easing.Quadratic.In;
+        }
+        break;
+      }
+    }
+
+    // Set initial properties for mesh
+    this._mesh.position.set(startX, startY, startZ);
+    this._mesh.rotation.set(startRotX, startRotY, startRotZ);
+    this._mesh.scale.set(startScaleX, startScaleY, startScaleZ);
+
+    const delta = {
+      px: startX,
+      py: startY,
+      pz: startZ,
+      rx: startRotX,
+      ry: startRotY,
+      rz: startRotZ,
+      sx: startScaleX,
+      sy: startScaleY,
+      sz: startScaleZ,
+      o: start ? 0.0 : 1.0,
+    };
+    const target = {
+      px: targetX,
+      py: targetY,
+      pz: targetZ,
+      rx: targetRotX,
+      ry: targetRotY,
+      rz: targetRotZ,
+      sx: targetScaleX,
+      sy: targetScaleY,
+      sz: targetScaleZ,
+      o: start ? 1.0 : 0.0,
+    };
+
+    const delay = delayOffset + MathUtils.randInt(100, 600);
+
     this._levelChangeTween = new Tween(delta, true)
-      .to(target, 2500)
-      .delay(MathUtils.randInt(250, 1500))
+      .to(target, 2200)
+      .delay(delay)
+      .easing(easingFunc)
       .onUpdate(() => {
+        this._mesh.position.set(delta.px, delta.py, delta.pz);
+        this._mesh.rotation.set(delta.rx, delta.ry, delta.rz);
+        this._mesh.scale.set(delta.sx, delta.sy, delta.sz);
         this._pieceMaterials?.forEach((m) => {
           if (m.useBasic) {
             m.materialBasic.opacity = delta.o;
@@ -229,6 +383,13 @@ export class GamePiece extends Object3D {
             m.materialPhong.opacity = delta.o;
           }
         });
+      })
+      .onComplete(() => {
+        if (start) {
+          this._mesh.position.set(0, 0, 0);
+          this._mesh.rotation.set(0, 0, 0);
+          this._mesh.scale.set(1, 1, 1);
+        }
       })
       .start();
   }

--- a/src/app/game/models/game-wheel.ts
+++ b/src/app/game/models/game-wheel.ts
@@ -7,6 +7,8 @@ import { GamePiece } from './game-piece/game-piece';
 import { PiecePoints } from './piece-points';
 import { PowerMoveType } from './power-move-type';
 
+import { LevelAnimationStyle } from './level-animation-style';
+
 export class GameWheel extends Object3D {
   private _theta = 0;
   private _moveStartTheta = 0;
@@ -89,7 +91,13 @@ export class GameWheel extends Object3D {
     }
   }
 
-  public AnimateLevelStartTween(targetY: number, delay: number, start: boolean, spinDirection: number): void {
+  public AnimateLevelStartTween(
+    targetY: number,
+    delay: number,
+    start: boolean,
+    spinDirection: number,
+    animationStyle: LevelAnimationStyle = LevelAnimationStyle.RadialAssemble,
+  ): void {
     this._levelChangeTween?.stop();
 
     let introSpinRangeMin = -10;
@@ -126,9 +134,9 @@ export class GameWheel extends Object3D {
       })
       .start();
 
-    // opacity of each game piece
+    // opacity & 3D transformation of each game piece
     for (const gamePiece of this.children as GamePiece[]) {
-      gamePiece.AnimateLevelChangeTween(start);
+      gamePiece.AnimateLevelChangeTween(start, animationStyle, delay);
     }
   }
 

--- a/src/app/game/models/level-animation-style.ts
+++ b/src/app/game/models/level-animation-style.ts
@@ -1,0 +1,13 @@
+export enum LevelAnimationStyle {
+  RadialAssemble,
+  SpiralVortex,
+  ScatterSnap,
+  CascadeWave,
+}
+
+export const LEVEL_ANIMATION_STYLES: readonly LevelAnimationStyle[] = [
+  LevelAnimationStyle.RadialAssemble,
+  LevelAnimationStyle.SpiralVortex,
+  LevelAnimationStyle.ScatterSnap,
+  LevelAnimationStyle.CascadeWave,
+];

--- a/src/app/game/services/effects-manager.spec.ts
+++ b/src/app/game/services/effects-manager.spec.ts
@@ -1,6 +1,10 @@
 import { TestBed } from '@angular/core/testing';
+import { PerspectiveCamera, PointLight } from 'three';
+import { vi } from 'vitest';
 
-import { EffectsManager } from './effects-manager';
+import { EffectsManagerService as EffectsManager } from './effects-manager';
+import { GameWheel } from '../models/game-wheel';
+import { LevelAnimationStyle } from '../models/level-animation-style';
 
 describe('EffectsManager', () => {
   let service: EffectsManager;
@@ -12,5 +16,18 @@ describe('EffectsManager', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should trigger AnimateLevelChangeAnimation with custom LevelAnimationStyle', () => {
+    const wheels = [new GameWheel(0, [])];
+    const verticalTargets = [0];
+    const camera = new PerspectiveCamera();
+    const light = new PointLight();
+
+    const spy = vi.spyOn(wheels[0], 'AnimateLevelStartTween');
+
+    service.AnimateLevelChangeAnimation(wheels, verticalTargets, camera, light, true, LevelAnimationStyle.SpiralVortex);
+
+    expect(spy).toHaveBeenCalledWith(0, expect.any(Number), true, expect.any(Number), LevelAnimationStyle.SpiralVortex);
   });
 });

--- a/src/app/game/services/effects-manager.ts
+++ b/src/app/game/services/effects-manager.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Injectable, inject } from '@angular/core';
+import { EventEmitter, Injectable, inject, isDevMode } from '@angular/core';
 
 import { Tween } from '@tweenjs/tween.js';
 import { MathUtils, Object3D, PerspectiveCamera, PointLight } from 'three';
@@ -12,6 +12,7 @@ import { GameWheel } from '../models/game-wheel';
 import { AudioType } from '../../shared/services/audio/audio-data';
 import { PowerMoveType } from '../models/power-move-type';
 import { SaveGameScore } from './save-game/save-game-types';
+import { LEVEL_ANIMATION_STYLES, LevelAnimationStyle } from '../models/level-animation-style';
 
 @Injectable({
   providedIn: 'root',
@@ -38,6 +39,7 @@ export class EffectsManagerService {
     camera: PerspectiveCamera,
     light: PointLight,
     start: boolean,
+    customStyle?: LevelAnimationStyle,
   ): void {
     // clear selected for highlighting
     if (start) {
@@ -47,19 +49,19 @@ export class EffectsManagerService {
     // lock board (interact manager)
     this.LevelChangeAnimation.next(true);
 
-    // stop currently running tween
+    // stop currently running camera tweens
     this._levelChangeCameraTween1?.stop();
     this._levelChangeCameraTween2?.stop();
 
-    let vTargets = [...verticalTargets];
-    if (!start) {
-      vTargets = verticalTargets.map(() => {
-        return -WHEEL_START_POSITION;
-      });
+    // Select random level transition animation style if not explicitly passed
+    const activeStyle = customStyle ?? LEVEL_ANIMATION_STYLES[MathUtils.randInt(0, LEVEL_ANIMATION_STYLES.length - 1)];
+
+    if (isDevMode()) {
+      console.info('Level Animation Style: ', LevelAnimationStyle[activeStyle]);
     }
 
     // animate camera
-    const delta1 = start ? { z: 5.0, rotX: 0, l: 400 } : { z: 5.0, rotX: 0, l: 400 };
+    const delta1 = { z: 5.0, rotX: 0, l: 400 };
     const target1 = start ? { z: 0, rotX: HALF_PI, l: 2000 } : { z: 0, rotX: -HALF_PI, l: 2000 };
     this._levelChangeCameraTween1 = new Tween(delta1, true).to(target1, start ? 750 : 3000).onUpdate(() => {
       camera.rotation.x = delta1.rotX;
@@ -68,7 +70,7 @@ export class EffectsManagerService {
     });
 
     const delta2 = start ? { z: 0, rotX: HALF_PI, l: 2000 } : { z: 0, rotX: -HALF_PI, l: 2000 };
-    const target2 = start ? { z: 5.0, rotX: 0, l: 400 } : { z: 5.0, rotX: 0, l: 400 };
+    const target2 = { z: 5.0, rotX: 0, l: 400 };
     this._levelChangeCameraTween2 = new Tween(delta2, true)
       .to(target2, 2000)
       .delay(1250)
@@ -87,8 +89,9 @@ export class EffectsManagerService {
     const introSpinDirection = MathUtils.randInt(1, 3);
     let delay = 0;
     gameWheels.forEach((wheel, inx) => {
-      delay += 250;
-      wheel.AnimateLevelStartTween(vTargets[inx], delay, start, introSpinDirection);
+      delay += 200;
+      const targetY = start ? verticalTargets[inx] : -WHEEL_START_POSITION;
+      wheel.AnimateLevelStartTween(targetY, delay, start, introSpinDirection, activeStyle);
     });
 
     this._levelChangeCameraTween1.chain(this._levelChangeCameraTween2);

--- a/src/app/game/services/material/material-manager.ts
+++ b/src/app/game/services/material/material-manager.ts
@@ -255,14 +255,14 @@ export class MaterialManagerService {
     const sortedColors = scheme.colors.sort();
 
     if (isDevMode()) {
-      console.info('  color scheme:', scheme.id);
+      console.info('  Color Scheme:', scheme.id);
       console.info('    ' + sortedColors.map((c) => `%c ${c}`).join(''), ...sortedColors.map((c) => `color: ${c}`));
     }
 
     const shuffledColors = arrayShuffle(sortedColors).slice(0, playableTextureCount);
 
     if (isDevMode()) {
-      console.info('    game piece colors:', scheme);
+      console.info('    Game Piece Colors:', scheme);
       console.info('    ' + shuffledColors.map((c) => `%c ${c}`).join(''), ...shuffledColors.map((c) => `color: ${c}`));
     }
 

--- a/src/app/game/services/texture/texture-manager.ts
+++ b/src/app/game/services/texture/texture-manager.ts
@@ -139,7 +139,7 @@ export class TextureManagerService {
         });
 
         if (isDevMode()) {
-          emojiList.forEach((emoji) => console.info(`  ${emoji.desc} ${emoji.sequence}`));
+          console.info(emojiList.map((emoji) => `  ${emoji.desc} ${emoji.sequence}`).join('\n'));
         }
         break;
     }


### PR DESCRIPTION
 #### Summary

  Introduces 4 randomized 3D level transition animation styles (Radial Assemble, Spiral Vortex, Scatter Snap, and X-axis
  Cascade Wave) for level start and level complete sequences, while optimizing memory allocations and camera tween management
  across EffectsManagerService and ObjectManagerService.

  #### Key Changes

  • 3D Level Transition Animations: Added procedural 3D local mesh transformations (position, rotation, scale, opacity) to
  GamePiece triggered during level start and level completion.
  • CascadeWave Refinement: Tuned CascadeWave to bounce smoothly along the X axis with subtle horizontal stretching.
  • Service Optimizations: Exported LEVEL_ANIMATION_STYLES constant to prevent per-transition allocations and streamlined
  camera tween lifecycles in EffectsManagerService.
  • Test Suite: Added unit test coverage for level transition animation styles using Vitest.

  #### Verification

  • Verified transition animations and piece snap-to-grid accuracy in dev server (npm start).
  • Vitest unit tests pass (npm test).