### PR TITLE
refactor(events): replace service-level EventEmitters with RxJS Subjects

### DIFF
--- a/src/app/game/components/dialogs/components/level-complete/level-complete.ts
+++ b/src/app/game/components/dialogs/components/level-complete/level-complete.ts
@@ -3,7 +3,6 @@ import {
   AfterViewInit,
   Component,
   ElementRef,
-  EventEmitter,
   OnDestroy,
   ViewChild,
   DestroyRef,
@@ -13,7 +12,7 @@ import {
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { delay } from 'rxjs';
+import { delay, Subject } from 'rxjs';
 import { Tween } from '@tweenjs/tween.js';
 import { mainTweenGroup } from '../../../../services/tween-group';
 
@@ -61,7 +60,7 @@ export class LevelComplete implements OnDestroy, AfterViewInit {
   pieceCount = 0;
 
   private _timerQueue: LevelStat[] = [];
-  private _timerEvent: EventEmitter<LevelStat> = new EventEmitter<LevelStat>();
+  private _timerEvent: Subject<LevelStat> = new Subject<LevelStat>();
 
   borderStyle!: string;
 

--- a/src/app/game/components/dialogs/services/dialog-notify.spec.ts
+++ b/src/app/game/components/dialogs/services/dialog-notify.spec.ts
@@ -13,4 +13,13 @@ describe('DialogNotify', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('should emit via DialogNotifyEvent when Notify is called', () => {
+    let emitted = false;
+    service.DialogNotifyEvent.subscribe(() => {
+      emitted = true;
+    });
+    service.Notify();
+    expect(emitted).toBe(true);
+  });
 });

--- a/src/app/game/components/dialogs/services/dialog-notify.ts
+++ b/src/app/game/components/dialogs/services/dialog-notify.ts
@@ -1,17 +1,18 @@
-import { EventEmitter, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class DialogNotifyService {
-  private _dialogEvent: EventEmitter<void>;
+  private _dialogEvent: Subject<void>;
 
-  get DialogNotifyEvent(): EventEmitter<void> {
-    return this._dialogEvent;
+  get DialogNotifyEvent(): Observable<void> {
+    return this._dialogEvent.asObservable();
   }
 
   constructor() {
-    this._dialogEvent = new EventEmitter<void>();
+    this._dialogEvent = new Subject<void>();
   }
 
   public Notify(): void {

--- a/src/app/game/services/effects-manager.spec.ts
+++ b/src/app/game/services/effects-manager.spec.ts
@@ -40,4 +40,18 @@ describe('EffectsManager', () => {
     service.AnimateGravity([], GravityType.None);
     expect(completed).toBe(true);
   });
+
+  it('should emit LevelChangeAnimation state during level transitions', () => {
+    let animationState: boolean | undefined;
+    service.LevelChangeAnimation.subscribe((state) => {
+      animationState = state;
+    });
+
+    const wheels = [new GameWheel(0, [])];
+    const camera = new PerspectiveCamera();
+    const light = new PointLight();
+
+    service.AnimateLevelChangeAnimation(wheels, [0], camera, light, true);
+    expect(animationState).toBe(true);
+  });
 });

--- a/src/app/game/services/effects-manager.ts
+++ b/src/app/game/services/effects-manager.ts
@@ -1,4 +1,5 @@
-import { EventEmitter, Injectable, inject, isDevMode } from '@angular/core';
+import { Injectable, inject, isDevMode } from '@angular/core';
+import { Subject } from 'rxjs';
 
 import { Tween } from '@tweenjs/tween.js';
 import { mainTweenGroup } from './tween-group';
@@ -45,9 +46,9 @@ export class EffectsManagerService {
     return this._selectedPieces;
   }
 
-  SelectionAnimationComplete: EventEmitter<boolean> = new EventEmitter();
-  LevelChangeAnimation: EventEmitter<boolean> = new EventEmitter();
-  GravityAnimationComplete: EventEmitter<void> = new EventEmitter();
+  SelectionAnimationComplete: Subject<boolean> = new Subject<boolean>();
+  LevelChangeAnimation: Subject<boolean> = new Subject<boolean>();
+  GravityAnimationComplete: Subject<void> = new Subject<void>();
 
   public AnimateLevelChangeAnimation(
     gameWheels: GameWheel[],
@@ -237,7 +238,7 @@ export class EffectsManagerService {
 
   public AnimateGravity(axle: GameWheel[], gravityType: GravityType): void {
     if (gravityType === GravityType.None || !axle.length) {
-      this.GravityAnimationComplete.emit();
+      this.GravityAnimationComplete.next();
       return;
     }
 
@@ -389,7 +390,7 @@ export class EffectsManagerService {
     }
 
     if (!hasAnyShift || actionsToAnimate.length === 0) {
-      this.GravityAnimationComplete.emit();
+      this.GravityAnimationComplete.next();
       return;
     }
 
@@ -426,13 +427,13 @@ export class EffectsManagerService {
       new Tween({ t: 0 }, mainTweenGroup)
         .to({ t: 1 }, duration)
         .onComplete(() => {
-          this.GravityAnimationComplete.emit();
+          this.GravityAnimationComplete.next();
         })
         .start();
 
       tweens.forEach((t) => t.start());
     } else {
-      this.GravityAnimationComplete.emit();
+      this.GravityAnimationComplete.next();
     }
   }
 

--- a/src/app/game/services/object-manager.spec.ts
+++ b/src/app/game/services/object-manager.spec.ts
@@ -13,4 +13,22 @@ describe('ObjectManager', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('should emit LevelCompleted event', () => {
+    let completed = false;
+    service.LevelCompleted.subscribe((win) => {
+      completed = win;
+    });
+    service.LevelCompleted.next(true);
+    expect(completed).toBe(true);
+  });
+
+  it('should emit LevelChangeAnimationComplete event', () => {
+    let animComplete = false;
+    service.LevelChangeAnimationComplete.subscribe(() => {
+      animComplete = true;
+    });
+    service.LevelChangeAnimationComplete.next();
+    expect(animComplete).toBe(true);
+  });
 });

--- a/src/app/game/services/object-manager.ts
+++ b/src/app/game/services/object-manager.ts
@@ -1,6 +1,6 @@
-import { EventEmitter, Injectable, inject } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
-import { BehaviorSubject, Observable, take } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, take } from 'rxjs';
 import { Group, MathUtils, PerspectiveCamera, PointLight, Scene, Vector3 } from 'three';
 
 import { GameWheel } from '../models/game-wheel';
@@ -55,8 +55,8 @@ export class ObjectManagerService {
   private _starField: StarField;
 
   // events
-  public LevelChangeAnimationComplete: EventEmitter<void> = new EventEmitter();
-  public LevelCompleted: EventEmitter<boolean> = new EventEmitter();
+  public LevelChangeAnimationComplete: Subject<void> = new Subject<void>();
+  public LevelCompleted: Subject<boolean> = new Subject<boolean>();
   public LevelMaterialsUpdated: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
 
   constructor() {

--- a/src/app/game/services/scoring-manager.spec.ts
+++ b/src/app/game/services/scoring-manager.spec.ts
@@ -41,12 +41,19 @@ describe('ScoringManagerService', () => {
     expect(service.LevelProgress).toBe((1 / target) * 100);
   });
 
-  it('should decrement moves on UpdateMoveCount and detect GameOver', () => {
+  it('should decrement moves on UpdateMoveCount, emit MovesChange, and detect GameOver', () => {
     const initialMoves = service.PlayerMoves;
     expect(initialMoves).toBeGreaterThan(0);
 
+    let movesChangedEmitted = false;
+    service.MovesChange.subscribe((increase) => {
+      movesChangedEmitted = true;
+      expect(increase).toBe(false);
+    });
+
     service.UpdateMoveCount();
     expect(service.PlayerMoves).toBe(initialMoves - 1);
+    expect(movesChangedEmitted).toBe(true);
 
     // Force moves to 0
     while (service.PlayerMoves > 0) {

--- a/src/app/game/services/scoring-manager.ts
+++ b/src/app/game/services/scoring-manager.ts
@@ -1,4 +1,5 @@
-import { EventEmitter, Injectable, inject, signal } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
+import { Subject } from 'rxjs';
 import { MathUtils } from 'three';
 import {
   DIFFICULTY_TIER_3,
@@ -28,7 +29,7 @@ export class ScoringManagerService {
   private _timeStop!: number;
 
   // events
-  public MovesChange: EventEmitter<boolean> = new EventEmitter();
+  public MovesChange: Subject<boolean> = new Subject<boolean>();
 
   // Signals for template reactivity
   readonly level = signal<number>(1);

--- a/src/app/game/services/share-manager.spec.ts
+++ b/src/app/game/services/share-manager.spec.ts
@@ -13,4 +13,23 @@ describe('ShareManager', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('should emit ShareInitiated and ShareFailed events via Subject', () => {
+    let initiated = false;
+    let failed = false;
+
+    service.ShareInitiated.subscribe(() => {
+      initiated = true;
+    });
+
+    service.ShareFailed.subscribe(() => {
+      failed = true;
+    });
+
+    service.ShareInitiated.next();
+    service.ShareFailed.next();
+
+    expect(initiated).toBe(true);
+    expect(failed).toBe(true);
+  });
 });

--- a/src/app/game/services/share-manager.ts
+++ b/src/app/game/services/share-manager.ts
@@ -1,6 +1,6 @@
-import { EventEmitter, Injectable, inject, signal } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
 import { DOCUMENT, formatNumber } from '@angular/common';
-import { forkJoin, Observable } from 'rxjs';
+import { forkJoin, Observable, Subject } from 'rxjs';
 import { SHARE_FILE_NAME } from '../game-constants';
 import { ScoringManagerService } from './scoring-manager';
 
@@ -24,8 +24,8 @@ export class ShareManagerService {
     return this._inLevel();
   }
 
-  public ShareInitiated: EventEmitter<void> = new EventEmitter();
-  public ShareFailed: EventEmitter<void> = new EventEmitter();
+  public ShareInitiated: Subject<void> = new Subject<void>();
+  public ShareFailed: Subject<void> = new Subject<void>();
 
   public UpdateInLevel(inLevel: boolean): void {
     this._inLevel.set(inLevel);

--- a/src/app/game/services/texture/texture-manager.spec.ts
+++ b/src/app/game/services/texture/texture-manager.spec.ts
@@ -13,4 +13,14 @@ describe('TextureManager', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('should emit texture load progress via Subject stream', () => {
+    let progressVal = 0;
+    service.LevelTextureLoadProgress.subscribe((p) => {
+      progressVal = p;
+    });
+
+    service.LevelTextureLoadProgress.next(50);
+    expect(progressVal).toBe(50);
+  });
 });

--- a/src/app/game/services/texture/texture-manager.ts
+++ b/src/app/game/services/texture/texture-manager.ts
@@ -1,6 +1,6 @@
 import { DOCUMENT } from '@angular/common';
-import { EventEmitter, Injectable, inject, isDevMode } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { Injectable, inject, isDevMode } from '@angular/core';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
 import { StoreService } from '../../../app-store/services/store.service';
 import { SaveGameService } from '../save-game/save-game';
@@ -58,11 +58,11 @@ export class TextureManagerService {
     return this._textures;
   }
 
-  public LevelTextureLoadingStarted: EventEmitter<boolean> = new EventEmitter();
+  public LevelTextureLoadingStarted: Subject<boolean> = new Subject<boolean>();
   public LevelTexturesLoaded: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
-  public LevelTexturesRestoredLoaded: EventEmitter<void> = new EventEmitter();
-  public LevelTextureLoadProgress: EventEmitter<number> = new EventEmitter();
-  public LevelTextureLoadError: EventEmitter<string> = new EventEmitter();
+  public LevelTexturesRestoredLoaded: Subject<void> = new Subject<void>();
+  public LevelTextureLoadProgress: Subject<number> = new Subject<number>();
+  public LevelTextureLoadError: Subject<string> = new Subject<string>();
 
   constructor() {
     this._loaderManager = new LoadingManager(

--- a/src/app/shared/services/app-visibility.ts
+++ b/src/app/shared/services/app-visibility.ts
@@ -1,13 +1,14 @@
-import { EventEmitter, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AppVisibilityService {
-  VisibilityChanged: EventEmitter<boolean>;
+  VisibilityChanged: Subject<boolean>;
 
   constructor() {
-    this.VisibilityChanged = new EventEmitter<boolean>();
+    this.VisibilityChanged = new Subject<boolean>();
   }
 }
 

--- a/src/app/shared/services/notify.spec.ts
+++ b/src/app/shared/services/notify.spec.ts
@@ -13,4 +13,13 @@ describe('Notify', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('should emit via NotifyEvent when Notify is called', () => {
+    let emitted = false;
+    service.NotifyEvent.subscribe(() => {
+      emitted = true;
+    });
+    service.Notify();
+    expect(emitted).toBe(true);
+  });
 });

--- a/src/app/shared/services/notify.ts
+++ b/src/app/shared/services/notify.ts
@@ -1,17 +1,18 @@
-import { EventEmitter, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class NotifyService {
-  private _notifyEvent: EventEmitter<void>;
+  private _notifyEvent: Subject<void>;
 
-  get NotifyEvent(): EventEmitter<void> {
-    return this._notifyEvent;
+  get NotifyEvent(): Observable<void> {
+    return this._notifyEvent.asObservable();
   }
 
   constructor() {
-    this._notifyEvent = new EventEmitter<void>();
+    this._notifyEvent = new Subject<void>();
   }
 
   public Notify(): void {


### PR DESCRIPTION
    ## Summary

    This PR refactors all service-level `EventEmitter` usages across **Rikkle** to native **RxJS `Subject`
  and `BehaviorSubject`** primitives.

    In Angular, `EventEmitter` is intended exclusively for `@Output()` component DOM bindings. Using
  `EventEmitter` in singleton `@Injectable()` services is a legacy pattern. Replacing them with `Subject`
  cleans up core framework misuse while maintaining immediate, synchronous event execution across Three.js
  animation frames.