### PR TITLE
  refactor(ui): convert component state and inputs to Angular Signals

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -22,8 +22,8 @@ self.addEventListener('install', (event) => {
           PRECACHE_ASSETS.map((url) =>
             cache.add(url).catch((err) => {
               console.warn(`[SW] Precache failed for ${url}:`, err);
-            })
-          )
+            }),
+          ),
         );
       })
       .then(() => self.skipWaiting()),

--- a/src/app/game/components/dialogs/components/game-over/game-over.html
+++ b/src/app/game/components/dialogs/components/game-over/game-over.html
@@ -1,19 +1,23 @@
 <div id="game-over" class="glass-dialog">
   <h1 class="text-center">No More Moves</h1>
   <mat-dialog-content>
-    <p class="game-over-emoji">{{ gameOverEmoji }}</p>
+    <p class="game-over-emoji">{{ gameOverEmoji() }}</p>
     <p class="text-center">You have exhausted your supply of moves!</p>
-    <wgl-progress-bar class="progress" [class.fade-out]="!texturesStillLoading" [value]="progress"></wgl-progress-bar>
+    <wgl-progress-bar
+      class="progress"
+      [class.fade-out]="!texturesStillLoading()"
+      [value]="progress()"
+    ></wgl-progress-bar>
     <wgl-high-scores></wgl-high-scores>
   </mat-dialog-content>
   <mat-dialog-actions align="center">
-    @if (!isLevelOne) {
-      <button mat-stroked-button color="primary" [disabled]="texturesStillLoading" (click)="onCloseRestartLevel()">
+    @if (!isLevelOne()) {
+      <button mat-stroked-button color="primary" [disabled]="texturesStillLoading()" (click)="onCloseRestartLevel()">
         Start Level {{ data.level }} again
       </button>
     }
-    <button mat-raised-button color="primary" [disabled]="texturesStillLoading" (click)="onCloseGameOver()">
-      @if (!isLevelOne) {
+    <button mat-raised-button color="primary" [disabled]="texturesStillLoading()" (click)="onCloseGameOver()">
+      @if (!isLevelOne()) {
         <span>Start Over</span>
       } @else {
         <span>Play again!</span>

--- a/src/app/game/components/dialogs/components/game-over/game-over.ts
+++ b/src/app/game/components/dialogs/components/game-over/game-over.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectorRef } from '@angular/core';
+import { Component, inject, ChangeDetectorRef, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
@@ -19,11 +19,13 @@ import { ProgressBar } from '../../../../../shared/components/progress-bar/progr
   styleUrl: './game-over.scss',
 })
 export class GameOver {
-  texturesStillLoading = true;
-  progress = 100;
+  texturesStillLoading = signal<boolean>(true);
+  progress = signal<number>(100);
 
-  isLevelOne: boolean;
-  gameOverEmoji = String.fromCodePoint(GAME_OVER_EMOJI[MathUtils.randInt(0, GAME_OVER_EMOJI.length - 1)]);
+  isLevelOne = signal<boolean>(false);
+  gameOverEmoji = signal<string>(
+    String.fromCodePoint(GAME_OVER_EMOJI[MathUtils.randInt(0, GAME_OVER_EMOJI.length - 1)]),
+  );
 
   private textureManager = inject(TextureManagerService);
   private dialogRef = inject(MatDialogRef<GameOver>);
@@ -34,17 +36,17 @@ export class GameOver {
   constructor() {
     this.textureManager.LevelTexturesLoaded.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((loaded) => {
       if (loaded) {
-        this.texturesStillLoading = false;
-        this.progress = 100;
+        this.texturesStillLoading.set(false);
+        this.progress.set(100);
         this.cdr.markForCheck();
       }
     });
     this.textureManager.LevelTextureLoadProgress.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((progress) => {
-      this.progress = progress;
+      this.progress.set(progress);
       this.cdr.markForCheck();
     });
 
-    this.isLevelOne = this.data?.level === 1;
+    this.isLevelOne.set(this.data?.level === 1);
   }
 
   onCloseGameOver(): void {

--- a/src/app/game/components/dialogs/components/level-complete/level-complete.html
+++ b/src/app/game/components/dialogs/components/level-complete/level-complete.html
@@ -1,36 +1,40 @@
-<div id="level-dialog" class="glass-dialog has-canvas-animation" [style]="borderStyle">
+<div id="level-dialog" class="glass-dialog has-canvas-animation" [style]="borderStyle()">
   <canvas #dialogCanvas class="canvas-backer"></canvas>
-  <h1 class="dialog-header">{{ LevelHeadingPhrase }}</h1>
+  <h1 class="dialog-header">{{ LevelHeadingPhrase() }}</h1>
 
   <mat-dialog-content class="content">
-    <div class="level-info-line" [class.show]="fastMatchBonusTotal">
+    <div class="level-info-line" [class.show]="fastMatchBonusTotal()">
       <span>Speed bonus</span>
-      <wgl-text-zoom [text]="fastMatchBonusTotal"></wgl-text-zoom>
+      <wgl-text-zoom [text]="fastMatchBonusTotal()"></wgl-text-zoom>
     </div>
-    <div class="level-info-line" [class.show]="fastestMatchTime">
+    <div class="level-info-line" [class.show]="fastestMatchTime()">
       <span>Fastest match</span>
-      <wgl-text-zoom [text]="fastestMatchTime"></wgl-text-zoom>
+      <wgl-text-zoom [text]="fastestMatchTime()"></wgl-text-zoom>
     </div>
-    <div class="level-info-line bad" [class.show]="moveCount">
+    <div class="level-info-line bad" [class.show]="moveCount()">
       <span>Moves used</span>
-      <wgl-text-zoom [text]="moveCount"></wgl-text-zoom>
+      <wgl-text-zoom [text]="moveCount()"></wgl-text-zoom>
     </div>
-    <div class="level-info-line good" [class.show]="moveCountEarned">
+    <div class="level-info-line good" [class.show]="moveCountEarned()">
       <span>Moves earned</span>
-      <wgl-text-zoom [text]="moveCountEarned"></wgl-text-zoom>
+      <wgl-text-zoom [text]="moveCountEarned()"></wgl-text-zoom>
     </div>
-    <div class="level-info-line" [class.show]="pieceCount">
+    <div class="level-info-line" [class.show]="pieceCount()">
       <span>Pieces</span>
-      <wgl-text-zoom [text]="pieceCount"></wgl-text-zoom>
+      <wgl-text-zoom [text]="pieceCount()"></wgl-text-zoom>
     </div>
-    <wgl-progress-bar class="progress" [class.fade-out]="!texturesStillLoading" [value]="progress"></wgl-progress-bar>
+    <wgl-progress-bar
+      class="progress"
+      [class.fade-out]="!texturesStillLoading()"
+      [value]="progress()"
+    ></wgl-progress-bar>
   </mat-dialog-content>
   <mat-dialog-actions align="center">
     <button
       mat-raised-button
       color="primary"
       (click)="NextLevel()"
-      [disabled]="texturesStillLoading || levelInfoProcessing"
+      [disabled]="texturesStillLoading() || levelInfoProcessing()"
     >
       <span>Next Level</span>
     </button>

--- a/src/app/game/components/dialogs/components/level-complete/level-complete.ts
+++ b/src/app/game/components/dialogs/components/level-complete/level-complete.ts
@@ -8,6 +8,8 @@ import {
   DestroyRef,
   inject,
   ChangeDetectorRef,
+  signal,
+  computed,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
@@ -49,20 +51,29 @@ interface LevelStat {
   styleUrl: './level-complete.scss',
 })
 export class LevelComplete implements OnDestroy, AfterViewInit {
-  texturesStillLoading = true;
-  levelInfoProcessing = true;
-  progress = 100;
+  texturesStillLoading = signal<boolean>(true);
+  levelInfoProcessing = signal<boolean>(true);
+  progress = signal<number>(100);
 
-  fastMatchBonusTotal = 0;
-  fastestMatchTime!: string;
-  moveCount = 0;
-  moveCountEarned = 0;
-  pieceCount = 0;
+  fastMatchBonusTotal = signal<number>(0);
+  fastestMatchTimeRaw = signal<number>(0);
+  fastestMatchTime = computed<string>(() => {
+    const raw = this.fastestMatchTimeRaw();
+    if (this.fastMatchBonusTotal() && raw) {
+      const roundedTime = Math.round((raw / 1000) * 100) / 100;
+      return `${roundedTime}s`;
+    }
+    return '';
+  });
+
+  moveCount = signal<number>(0);
+  moveCountEarned = signal<number>(0);
+  pieceCount = signal<number>(0);
 
   private _timerQueue: LevelStat[] = [];
   private _timerEvent: Subject<LevelStat> = new Subject<LevelStat>();
 
-  borderStyle!: string;
+  borderStyle = signal<string>('');
 
   @ViewChild('dialogCanvas')
   dialogCanvas!: ElementRef<HTMLCanvasElement>;
@@ -77,18 +88,20 @@ export class LevelComplete implements OnDestroy, AfterViewInit {
   private destroyRef = inject(DestroyRef);
   private cdr = inject(ChangeDetectorRef);
 
-  LevelHeadingPhrase!: string;
+  LevelHeadingPhrase = signal<string>(
+    LEVEL_COMPLETE_HEADINGS[Math.floor(Math.random() * LEVEL_COMPLETE_HEADINGS.length)],
+  );
 
   constructor() {
     this.textureManager.LevelTexturesLoaded.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((loaded) => {
       if (loaded) {
-        this.texturesStillLoading = false;
-        this.progress = 100;
+        this.texturesStillLoading.set(false);
+        this.progress.set(100);
         this.cdr.markForCheck();
       }
     });
     this.textureManager.LevelTextureLoadProgress.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((progress) => {
-      this.progress = progress;
+      this.progress.set(progress);
       this.cdr.markForCheck();
     });
 
@@ -99,10 +112,10 @@ export class LevelComplete implements OnDestroy, AfterViewInit {
         .repeat(2)
         .yoyo(true)
         .onUpdate(() => {
-          this.borderStyle = `border: ${delta.b}px dashed white`;
+          this.borderStyle.set(`border: ${delta.b}px dashed white`);
         })
         .onComplete(() => {
-          this.borderStyle = 'border: unset';
+          this.borderStyle.set('border: unset');
         })
         .start();
     });
@@ -113,36 +126,35 @@ export class LevelComplete implements OnDestroy, AfterViewInit {
       .subscribe((stat: LevelStat) => {
         switch (stat.statType) {
           case LevelStatisticType.fastMatchBonusTotal:
-            this.fastMatchBonusTotal = stat.statValue;
+            this.fastMatchBonusTotal.set(stat.statValue);
             this.audioManager.PlayAudio(AudioType.LEVEL_STAT, true);
             break;
 
           case LevelStatisticType.fastestMatchMs:
-            if (this.fastMatchBonusTotal) {
-              const roundedTime = Math.round((stat.statValue / 1000) * 100) / 100;
-              this.fastestMatchTime = `${roundedTime}s`;
+            if (this.fastMatchBonusTotal()) {
+              this.fastestMatchTimeRaw.set(stat.statValue);
               this.audioManager.PlayAudio(AudioType.LEVEL_STAT, true);
             }
             break;
 
           case LevelStatisticType.moveCount:
-            this.moveCount = stat.statValue;
+            this.moveCount.set(stat.statValue);
             this.audioManager.PlayAudio(AudioType.LEVEL_STAT, true);
             break;
 
           case LevelStatisticType.moveCountEarned:
-            this.moveCountEarned = stat.statValue;
+            this.moveCountEarned.set(stat.statValue);
             this.audioManager.PlayAudio(AudioType.LEVEL_STAT, true);
             break;
 
           case LevelStatisticType.pieceCount:
-            this.pieceCount = stat.statValue;
+            this.pieceCount.set(stat.statValue);
             this.audioManager.PlayAudio(AudioType.LEVEL_STAT, true);
             break;
 
           case LevelStatisticType.infoComplete:
             this.audioManager.PlayAudio(AudioType.LEVEL_ENABLE_CTA);
-            this.levelInfoProcessing = false;
+            this.levelInfoProcessing.set(false);
             break;
         }
 
@@ -153,8 +165,6 @@ export class LevelComplete implements OnDestroy, AfterViewInit {
     if (this.data) {
       this.setData(this.data);
     }
-
-    this.LevelHeadingPhrase = LEVEL_COMPLETE_HEADINGS[Math.floor(Math.random() * LEVEL_COMPLETE_HEADINGS.length)];
   }
 
   NextLevel(): void {
@@ -178,13 +188,13 @@ export class LevelComplete implements OnDestroy, AfterViewInit {
 
   private setData(levelData: any): void {
     this._timerQueue = [];
-    this.fastMatchBonusTotal = 0;
-    this.fastestMatchTime = '';
-    this.moveCount = 0;
-    this.moveCountEarned = 0;
-    this.pieceCount = 0;
+    this.fastMatchBonusTotal.set(0);
+    this.fastestMatchTimeRaw.set(0);
+    this.moveCount.set(0);
+    this.moveCountEarned.set(0);
+    this.pieceCount.set(0);
 
-    this.levelInfoProcessing = true;
+    this.levelInfoProcessing.set(true);
 
     if (levelData.stats?.fastMatchBonusTotal) {
       this._timerQueue.push({

--- a/src/app/game/components/dialogs/components/moves-remaining/moves-remaining.html
+++ b/src/app/game/components/dialogs/components/moves-remaining/moves-remaining.html
@@ -1,10 +1,10 @@
 <div id="moves-tutorial" class="glass-dialog">
   <div class="up-finger-wrapper">
-    <span class="up-finger">{{ indexFingerPointingUp }}</span>
+    <span class="up-finger">{{ indexFingerPointingUp() }}</span>
   </div>
   <h2 class="dialog-title">Hint: Moves</h2>
   <div mat-dialog-content class="content-body">
-    @if (showIncrease) {
+    @if (showIncrease()) {
       <p>Nice job!</p>
       <p>Moves are earned with <b>faster</b> and <b>longer</b> matches.</p>
     } @else {

--- a/src/app/game/components/dialogs/components/moves-remaining/moves-remaining.ts
+++ b/src/app/game/components/dialogs/components/moves-remaining/moves-remaining.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 
@@ -10,6 +10,6 @@ import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
   styleUrl: './moves-remaining.scss',
 })
 export class MovesRemaining {
-  indexFingerPointingUp = String.fromCodePoint(0x261d, 0xfe0f);
-  showIncrease: boolean = inject(MAT_DIALOG_DATA);
+  indexFingerPointingUp = signal<string>(String.fromCodePoint(0x261d, 0xfe0f));
+  showIncrease = signal<boolean>(inject(MAT_DIALOG_DATA));
 }

--- a/src/app/game/components/dialogs/components/user-settings/user-settings.html
+++ b/src/app/game/components/dialogs/components/user-settings/user-settings.html
@@ -8,58 +8,58 @@
     <!-- Game SFX Volume -->
     <div class="setting-row inline-row">
       <span class="setting-label">
-        <mat-icon class="setting-icon">{{ gameIcon }}</mat-icon>
+        <mat-icon class="setting-icon">{{ gameIcon() }}</mat-icon>
         <span>Game</span>
       </span>
       <div class="slider-container">
         <mat-slider min="0" max="100" step="1" class="volume-slider">
           <input
             matSliderThumb
-            [value]="gameVolume"
+            [value]="gameVolume()"
             (input)="onGameVolumeInput($event)"
             (change)="onGameVolumeChange($event)"
           />
         </mat-slider>
       </div>
-      <span class="setting-value">{{ gameVolume }}%</span>
+      <span class="setting-value">{{ gameVolume() }}%</span>
     </div>
 
     <!-- Background Music Volume -->
     <div class="setting-row inline-row">
       <span class="setting-label">
-        <mat-icon class="setting-icon">{{ musicIcon }}</mat-icon>
+        <mat-icon class="setting-icon">{{ musicIcon() }}</mat-icon>
         <span>Music</span>
       </span>
       <div class="slider-container">
         <mat-slider min="0" max="100" step="1" class="volume-slider">
           <input
             matSliderThumb
-            [value]="musicVolume"
+            [value]="musicVolume()"
             (input)="onMusicVolumeInput($event)"
             (change)="onMusicVolumeChange($event)"
           />
         </mat-slider>
       </div>
-      <span class="setting-value">{{ musicVolume }}%</span>
+      <span class="setting-value">{{ musicVolume() }}%</span>
     </div>
 
     <!-- Haptic Feedback Toggle -->
     <div class="setting-row toggle-wrapper">
       <div class="toggle-row">
-        <span class="setting-label" [class.disabled-label]="!isHapticsAvailable">
+        <span class="setting-label" [class.disabled-label]="!isHapticsAvailable()">
           <mat-icon class="setting-icon">vibration</mat-icon>
           <span>Haptic Feedback</span>
         </span>
         <mat-slide-toggle
-          [checked]="hapticsEnabled"
-          [disabled]="!isHapticsAvailable"
+          [checked]="hapticsEnabled()"
+          [disabled]="!isHapticsAvailable()"
           (change)="onHapticsChange($event.checked)"
           color="primary"
         ></mat-slide-toggle>
       </div>
-      <div class="haptics-unavailable-note" *ngIf="!isHapticsAvailable">
-        Haptic feedback is not available
-      </div>
+      @if (!isHapticsAvailable()) {
+        <div class="haptics-unavailable-note">Haptic feedback is not available</div>
+      }
     </div>
 
     <!-- High Scores Reset -->
@@ -70,19 +70,22 @@
           <span>High Scores</span>
         </span>
       </div>
-      <div class="action-container" *ngIf="!confirmClear">
-        <button mat-stroked-button color="warn" (click)="onPromptClearHighScores()" [disabled]="scoresCleared">
-          <mat-icon>delete_forever</mat-icon>
-          <span>{{ scoresCleared ? 'Scores Cleared' : 'Reset High Scores' }}</span>
-        </button>
-      </div>
-      <div class="confirm-container score-reset" *ngIf="confirmClear">
-        <span class="confirm-prompt">Clear all saved high scores?</span>
-        <div class="confirm-buttons">
-          <button mat-button (click)="onCancelClearHighScores()">Cancel</button>
-          <button mat-raised-button color="warn" (click)="onConfirmClearHighScores()">Clear</button>
+      @if (!confirmClear()) {
+        <div class="action-container">
+          <button mat-stroked-button color="warn" (click)="onPromptClearHighScores()" [disabled]="scoresCleared()">
+            <mat-icon>delete_forever</mat-icon>
+            <span>{{ scoresCleared() ? 'Scores Cleared' : 'Reset High Scores' }}</span>
+          </button>
         </div>
-      </div>
+      } @else {
+        <div class="confirm-container score-reset">
+          <span class="confirm-prompt">Clear all saved high scores?</span>
+          <div class="confirm-buttons">
+            <button mat-button (click)="onCancelClearHighScores()">Cancel</button>
+            <button mat-raised-button color="warn" (click)="onConfirmClearHighScores()">Clear</button>
+          </div>
+        </div>
+      }
     </div>
 
     <!-- Factory Reset -->
@@ -93,13 +96,15 @@
           <span>Factory Reset</span>
         </span>
       </div>
-      <div class="action-container" *ngIf="!factoryResetCompleted">
-        <button mat-stroked-button color="warn" (click)="onPromptFactoryReset()">
-          <mat-icon>local_fire_department</mat-icon>
-          <span>Nuke the Rikkle! 💥</span>
-        </button>
-      </div>
-      <mat-expansion-panel [expanded]="confirmFactoryReset" hideToggle class="reset-expansion-panel">
+      @if (!factoryResetCompleted()) {
+        <div class="action-container">
+          <button mat-stroked-button color="warn" (click)="onPromptFactoryReset()">
+            <mat-icon>local_fire_department</mat-icon>
+            <span>Nuke the Rikkle! 💥</span>
+          </button>
+        </div>
+      }
+      <mat-expansion-panel [expanded]="confirmFactoryReset()" hideToggle class="reset-expansion-panel">
         <div class="confirm-container factory-reset">
           <span class="confirm-prompt">
             💥 Are you sure? This will wipe out <strong>all local storage</strong>, including high scores, saved games,
@@ -114,10 +119,12 @@
           </div>
         </div>
       </mat-expansion-panel>
-      <div class="reset-success-message" *ngIf="factoryResetCompleted">
-        <mat-icon class="spin-icon">refresh</mat-icon>
-        <span>Rikkle Nuked! Reloading fresh game...</span>
-      </div>
+      @if (factoryResetCompleted()) {
+        <div class="reset-success-message">
+          <mat-icon class="spin-icon">refresh</mat-icon>
+          <span>Rikkle Nuked! Reloading fresh game...</span>
+        </div>
+      }
     </div>
   </div>
 

--- a/src/app/game/components/dialogs/components/user-settings/user-settings.spec.ts
+++ b/src/app/game/components/dialogs/components/user-settings/user-settings.spec.ts
@@ -47,7 +47,7 @@ describe('UserSettings', () => {
     expect(noteEl).toBeTruthy();
     expect(noteEl.textContent.trim()).toBe('Haptic feedback is not available');
     expect(toggleEl).toBeTruthy();
-    expect(component.isHapticsAvailable).toBe(false);
+    expect(component.isHapticsAvailable()).toBe(false);
   });
 
   it('should update game volume on input without playing audio', () => {
@@ -58,7 +58,7 @@ describe('UserSettings', () => {
     const fakeEvent = { target: { value: '75' } } as unknown as Event;
     component.onGameVolumeInput(fakeEvent);
 
-    expect(component.gameVolume).toBe(75);
+    expect(component.gameVolume()).toBe(75);
     expect(setGameVolumeSpy).toHaveBeenCalledWith(0.75);
     expect(playAudioSpy).not.toHaveBeenCalled();
   });
@@ -71,7 +71,7 @@ describe('UserSettings', () => {
     const fakeEvent = { target: { value: '80' } } as unknown as Event;
     component.onGameVolumeChange(fakeEvent);
 
-    expect(component.gameVolume).toBe(80);
+    expect(component.gameVolume()).toBe(80);
     expect(setGameVolumeSpy).toHaveBeenCalledWith(0.8);
     expect(playAudioSpy).toHaveBeenCalledWith(AudioType.LEVEL_STAT);
   });
@@ -84,7 +84,7 @@ describe('UserSettings', () => {
     const fakeEvent = { target: { value: '40' } } as unknown as Event;
     component.onMusicVolumeInput(fakeEvent);
 
-    expect(component.musicVolume).toBe(40);
+    expect(component.musicVolume()).toBe(40);
     expect(setMusicVolumeSpy).toHaveBeenCalledWith(0.4);
     expect(playAudioSpy).not.toHaveBeenCalled();
   });
@@ -98,7 +98,7 @@ describe('UserSettings', () => {
     const fakeEvent = { target: { value: '60' } } as unknown as Event;
     component.onMusicVolumeChange(fakeEvent);
 
-    expect(component.musicVolume).toBe(60);
+    expect(component.musicVolume()).toBe(60);
     expect(setMusicVolumeSpy).toHaveBeenCalledWith(0.6);
     expect(stopAudioSpy).toHaveBeenCalledWith(AudioType.LEVEL_END_7);
     expect(playAudioSpy).toHaveBeenCalledWith(AudioType.LEVEL_END_7, false, false, 2.0);

--- a/src/app/game/components/dialogs/components/user-settings/user-settings.ts
+++ b/src/app/game/components/dialogs/components/user-settings/user-settings.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, inject } from '@angular/core';
+import { Component, OnDestroy, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
@@ -33,30 +33,19 @@ export class UserSettings implements OnDestroy {
   private hapticsManager = inject(HapticsManagerService);
   private dialogRef = inject(MatDialogRef<UserSettings>);
 
-  gameVolume = Math.round(this.audioManager.GetGameVolume() * 100);
-  musicVolume = Math.round(this.audioManager.GetMusicVolume() * 100);
-  scoresCleared = false;
-  confirmClear = false;
-  confirmFactoryReset = false;
-  factoryResetCompleted = false;
+  gameVolume = signal<number>(Math.round(this.audioManager.GetGameVolume() * 100));
+  musicVolume = signal<number>(Math.round(this.audioManager.GetMusicVolume() * 100));
+  scoresCleared = signal<boolean>(false);
+  confirmClear = signal<boolean>(false);
+  confirmFactoryReset = signal<boolean>(false);
+  factoryResetCompleted = signal<boolean>(false);
 
   private musicPreviewTimeout?: ReturnType<typeof setTimeout>;
 
-  get gameIcon(): string {
-    return this.gameVolume === 0 ? 'volume_off' : 'volume_up';
-  }
-
-  get musicIcon(): string {
-    return this.musicVolume === 0 ? 'music_off' : 'music_note';
-  }
-
-  get isHapticsAvailable(): boolean {
-    return this.hapticsManager.isAvailable;
-  }
-
-  get hapticsEnabled(): boolean {
-    return this.hapticsManager.hapticsEnabled;
-  }
+  gameIcon = computed(() => (this.gameVolume() === 0 ? 'volume_off' : 'volume_up'));
+  musicIcon = computed(() => (this.musicVolume() === 0 ? 'music_off' : 'music_note'));
+  isHapticsAvailable = computed(() => this.hapticsManager.isAvailable);
+  hapticsEnabled = computed(() => this.hapticsManager.hapticsEnabled);
 
   onHapticsChange(enabled: boolean): void {
     this.hapticsManager.HapticsEnabled = enabled;
@@ -65,14 +54,14 @@ export class UserSettings implements OnDestroy {
   onGameVolumeInput(event: Event): void {
     const input = event.target as HTMLInputElement;
     const val = Number(input.value);
-    this.gameVolume = val;
+    this.gameVolume.set(val);
     this.audioManager.SetGameVolume(val / 100);
   }
 
   onGameVolumeChange(event: Event): void {
     const input = event.target as HTMLInputElement;
     const val = Number(input.value);
-    this.gameVolume = val;
+    this.gameVolume.set(val);
     this.audioManager.SetGameVolume(val / 100);
     this.audioManager.PlayAudio(AudioType.LEVEL_STAT);
   }
@@ -80,14 +69,14 @@ export class UserSettings implements OnDestroy {
   onMusicVolumeInput(event: Event): void {
     const input = event.target as HTMLInputElement;
     const val = Number(input.value);
-    this.musicVolume = val;
+    this.musicVolume.set(val);
     this.audioManager.SetMusicVolume(val / 100);
   }
 
   onMusicVolumeChange(event: Event): void {
     const input = event.target as HTMLInputElement;
     const val = Number(input.value);
-    this.musicVolume = val;
+    this.musicVolume.set(val);
     this.audioManager.SetMusicVolume(val / 100);
 
     if (this.musicPreviewTimeout) {
@@ -102,29 +91,29 @@ export class UserSettings implements OnDestroy {
   }
 
   onPromptClearHighScores(): void {
-    this.confirmClear = true;
+    this.confirmClear.set(true);
   }
 
   onConfirmClearHighScores(): void {
     this.highScoreManager.ClearHighScores();
-    this.scoresCleared = true;
-    this.confirmClear = false;
+    this.scoresCleared.set(true);
+    this.confirmClear.set(false);
   }
 
   onCancelClearHighScores(): void {
-    this.confirmClear = false;
+    this.confirmClear.set(false);
   }
 
   onPromptFactoryReset(): void {
-    this.confirmFactoryReset = !this.confirmFactoryReset;
+    this.confirmFactoryReset.set(!this.confirmFactoryReset());
   }
 
   onConfirmFactoryReset(): void {
     this.storageService.clear();
-    this.scoresCleared = true;
-    this.confirmClear = false;
-    this.confirmFactoryReset = false;
-    this.factoryResetCompleted = true;
+    this.scoresCleared.set(true);
+    this.confirmClear.set(false);
+    this.confirmFactoryReset.set(false);
+    this.factoryResetCompleted.set(true);
 
     setTimeout(() => {
       window.location.reload();
@@ -132,7 +121,7 @@ export class UserSettings implements OnDestroy {
   }
 
   onCancelFactoryReset(): void {
-    this.confirmFactoryReset = false;
+    this.confirmFactoryReset.set(false);
   }
 
   onClose(): void {

--- a/src/app/game/components/game-container/game-container.html
+++ b/src/app/game/components/game-container/game-container.html
@@ -13,7 +13,7 @@
     <div class="game-logo"></div>
     <wgl-text-zoom class="game-score" [text]="scoringManager.Score"></wgl-text-zoom>
     <wgl-moves-left class="moves-remaining" [amount]="scoringManager.PlayerMoves"></wgl-moves-left>
-    <div class="level-info" [style.color]="LevelLabelColor">
+    <div class="level-info" [style.color]="LevelLabelColor()">
       <span>Level</span>
       <span>&nbsp;</span>
       <div>{{ scoringManager.Level }}</div>
@@ -36,6 +36,6 @@
     [class.show]="splashPhase() !== 'black' && !showScoreProgress()"
     [class.hide]="showScoreProgress()"
   >
-    &copy; {{ copyrightYear }} David Teply
+    &copy; {{ copyrightYear() }} David Teply
   </div>
 </div>

--- a/src/app/game/components/game-container/game-container.ts
+++ b/src/app/game/components/game-container/game-container.ts
@@ -78,12 +78,12 @@ export class GameContainer implements OnInit, AfterViewInit {
 
   showScoreProgress = signal<boolean>(false);
   splashPhase = signal<'black' | 'image' | 'fade-out' | 'done'>('black');
-  LevelLabelColor!: string;
+  LevelLabelColor = signal<string>('');
 
   public GridTemplateColumns = '';
   public GridTemplateRows = '';
 
-  copyrightYear = new Date().getFullYear();
+  copyrightYear = signal<number>(new Date().getFullYear());
 
   constructor() {
     // set up window resizing event with automatic cleanup
@@ -322,7 +322,7 @@ export class GameContainer implements OnInit, AfterViewInit {
 
   private updateDifficultyColor(): void {
     // visual indicator for difficulty level
-    this.LevelLabelColor = `#${this.gameEngine.PlayableTextureCountColor.toString(16)}`;
+    this.LevelLabelColor.set(`#${this.gameEngine.PlayableTextureCountColor.toString(16)}`);
     this.objectManager.UpdateStarFieldColor(this.gameEngine.PlayableTextureCountColor);
   }
 }

--- a/src/app/game/components/high-scores/high-scores.html
+++ b/src/app/game/components/high-scores/high-scores.html
@@ -1,8 +1,8 @@
-@if (highScores?.length) {
+@if (highScores().length) {
   <div id="highScores">
     <div class="title">High Scores</div>
-    @for (highScore of highScores; track $index) {
-      <div class="score-entry" [class.new-entry]="showHighligh && highScore.highlight">
+    @for (highScore of highScores(); track $index) {
+      <div class="score-entry" [class.new-entry]="showHighligh() && highScore.highlight">
         <span>{{ highScore.occurred | date: 'mediumDate' }}</span>
         <span>{{ highScore.score | number }} </span>
       </div>

--- a/src/app/game/components/high-scores/high-scores.ts
+++ b/src/app/game/components/high-scores/high-scores.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, inject } from '@angular/core';
+import { Component, input, signal, OnInit, inject } from '@angular/core';
 import { CommonModule, DecimalPipe, DatePipe } from '@angular/common';
 import { HighScore, HighScoreManagerService } from '../../../shared/services/high-score-manager';
 
@@ -12,13 +12,12 @@ import { HighScore, HighScoreManagerService } from '../../../shared/services/hig
 export class HighScores implements OnInit {
   private highScoreManager = inject(HighScoreManagerService);
 
-  highScores!: HighScore[];
-
-  @Input() showHighligh = true;
+  highScores = signal<HighScore[]>([]);
+  showHighligh = input<boolean>(true);
 
   ngOnInit(): void {
     this.highScoreManager.GetHighScores().subscribe((highScores) => {
-      this.highScores = highScores;
+      this.highScores.set(highScores);
     });
   }
 }

--- a/src/app/game/components/share-content/share-content.html
+++ b/src/app/game/components/share-content/share-content.html
@@ -1,5 +1,7 @@
-<div id="share-content" *ngIf="ShowSelf">
-  <button mat-icon-button (click)="Share()" class="share-tab-btn" title="Share Rikkle" aria-label="Share Rikkle">
-    <mat-icon>share</mat-icon>
-  </button>
-</div>
+@if (ShowSelf()) {
+  <div id="share-content">
+    <button mat-icon-button (click)="Share()" class="share-tab-btn" title="Share Rikkle" aria-label="Share Rikkle">
+      <mat-icon>share</mat-icon>
+    </button>
+  </div>
+}

--- a/src/app/game/components/share-content/share-content.ts
+++ b/src/app/game/components/share-content/share-content.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, DOCUMENT, inject, OnInit } from '@angular/core';
+import { Component, DestroyRef, DOCUMENT, inject, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -18,27 +18,27 @@ export class ShareContent implements OnInit {
   private document = inject(DOCUMENT);
   private destroyRef = inject(DestroyRef);
 
-  ShowSelf = false;
-  Loading = false;
+  ShowSelf = signal<boolean>(false);
+  Loading = signal<boolean>(false);
 
   ngOnInit(): void {
     this.shareManager
       .CanShare()
       .pipe(take(1))
       .subscribe((result) => {
-        this.ShowSelf = result;
+        this.ShowSelf.set(result);
       });
 
     this.shareManager.ShareInitiated.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
-      this.Loading = false;
+      this.Loading.set(false);
     });
     this.shareManager.ShareFailed.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
-      this.Loading = false;
+      this.Loading.set(false);
     });
   }
 
   Share(): void {
-    this.Loading = true;
+    this.Loading.set(true);
     this.shareManager.RequestScreenShot(this.document);
   }
 }

--- a/src/app/game/services/material/material-manager.ts
+++ b/src/app/game/services/material/material-manager.ts
@@ -144,11 +144,7 @@ export class MaterialManagerService {
     return { materials: resultMaterials };
   }
 
-  private applyMaterialToSide(
-    side: PieceSideMaterial,
-    material: GamePieceMaterialData | undefined,
-    opacity = 0,
-  ): void {
+  private applyMaterialToSide(side: PieceSideMaterial, material: GamePieceMaterialData | undefined, opacity = 0): void {
     if (!material) return;
 
     side.matchKey = material.matchKey;

--- a/src/app/game/text/components/text-zoom/text-zoom.html
+++ b/src/app/game/text/components/text-zoom/text-zoom.html
@@ -1,5 +1,5 @@
 <div class="text-zoom-container">
-  @for (char of chars; track $index) {
+  @for (char of chars(); track $index) {
     <wgl-zoom-char [text]="char"></wgl-zoom-char>
   }
 </div>

--- a/src/app/game/text/components/text-zoom/text-zoom.ts
+++ b/src/app/game/text/components/text-zoom/text-zoom.ts
@@ -1,4 +1,4 @@
-import { Component, Input, inject } from '@angular/core';
+import { Component, computed, input, inject } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { ZoomChar } from './zoom-char/zoom-char';
 
@@ -12,14 +12,16 @@ import { ZoomChar } from './zoom-char/zoom-char';
 export class TextZoom {
   private decimalPipe = inject(DecimalPipe);
 
-  chars: string[] = [];
+  text = input<number | string>('');
 
-  @Input() set text(target: number | string) {
+  chars = computed<string[]>(() => {
+    const target = this.text();
     const formatted = Number(target) ? this.decimalPipe.transform(target) : target;
     if (formatted !== null && formatted !== undefined) {
-      this.chars = formatted.toString().split('');
+      return formatted.toString().split('');
     }
-  }
+    return [];
+  });
 }
 
 export { TextZoom as TextZoomComponent };

--- a/src/app/game/text/components/text-zoom/zoom-char/zoom-char.html
+++ b/src/app/game/text/components/text-zoom/zoom-char/zoom-char.html
@@ -1,1 +1,1 @@
-<div #charEl>{{ char }}</div>
+<div #charEl>{{ text() }}</div>

--- a/src/app/game/text/components/text-zoom/zoom-char/zoom-char.ts
+++ b/src/app/game/text/components/text-zoom/zoom-char/zoom-char.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, Input, OnDestroy, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, input, OnDestroy, ViewChild } from '@angular/core';
 import { Tween } from '@tweenjs/tween.js';
 import { mainTweenGroup } from '../../../../services/tween-group';
 
@@ -9,13 +9,9 @@ import { mainTweenGroup } from '../../../../services/tween-group';
   styleUrl: './zoom-char.scss',
 })
 export class ZoomChar implements AfterViewInit, OnDestroy {
-  char = '';
+  text = input<string>('');
 
   private _zoomTween: any;
-
-  @Input() set text(target: string) {
-    this.char = target;
-  }
 
   @ViewChild('charEl') localChar!: ElementRef<HTMLDivElement>;
 

--- a/src/app/shared/components/about/about.html
+++ b/src/app/shared/components/about/about.html
@@ -1,11 +1,11 @@
 <div id="about-dialog" class="glass-dialog">
   <h1 mat-dialog-title class="dialog-header">About</h1>
   <div mat-dialog-content>
-    @if (levelColors?.length) {
+    @if (levelColors().length) {
       <div>
         <h2>Colors</h2>
         <div class="level-colors">
-          @for (color of levelColors; track $index) {
+          @for (color of levelColors(); track $index) {
             <div>
               <div class="level-color">
                 <div class="color-block" [style.backgroundColor]="color"></div>
@@ -16,13 +16,13 @@
         </div>
       </div>
     }
-    @if (levelEmojis?.emojiList?.length) {
+    @if (levelEmojis()?.emojiList?.length) {
       <div>
         <h2>Emojis</h2>
-        <p>Group: {{ levelEmojis.group }}</p>
-        <p>Subgroups: {{ levelEmojis.subGroups?.join(', ') }}</p>
+        <p>Group: {{ levelEmojis()?.group }}</p>
+        <p>Subgroups: {{ levelEmojis()?.subGroups?.join(', ') }}</p>
         <div>
-          @for (emoji of levelEmojis.emojiList; track $index) {
+          @for (emoji of levelEmojis()?.emojiList; track $index) {
             <div>
               <p class="level-emoji-row">
                 <span class="level-emoji">{{ emoji.emojiCode }}</span> {{ emoji.desc }}

--- a/src/app/shared/components/about/about.ts
+++ b/src/app/shared/components/about/about.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
@@ -14,12 +14,12 @@ import { StoreService } from '../../../app-store/services/store.service';
 export class About implements OnInit {
   private store = inject(StoreService);
 
-  levelColors!: string[];
-  levelEmojis!: EmojiInfo;
+  levelColors = signal<string[]>([]);
+  levelEmojis = signal<EmojiInfo | undefined>(undefined);
 
   ngOnInit(): void {
-    this.levelColors = this.store.LevelColors;
-    this.levelEmojis = this.store.EmojiInfo;
+    this.levelColors.set(this.store.LevelColors);
+    this.levelEmojis.set(this.store.EmojiInfo);
   }
 }
 


### PR DESCRIPTION
   ## Summary

    This PR modernizes the component UI layer across Rikkle for Angular 22 and Zone-less readiness by
  refactoring legacy `@Input()` decorators, local view state properties, and derived values to Angular
  Signals (`input()`, `signal()`, `computed()`).