### PR TITLE
 fix(game): resolve lint errors, fix Vercel build, and synchronize gr…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/three": "^0.185.4",
         "angular-eslint": "22.1.0",
         "eslint": "^10.6.0",
+        "husky": "^9.1.7",
         "jsdom": "^28.0.0",
         "prettier": "^3.8.1",
         "typescript": "~6.0.2",
@@ -6446,6 +6447,22 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/src/app/game/models/game-piece/game-piece.ts
+++ b/src/app/game/models/game-piece/game-piece.ts
@@ -289,14 +289,16 @@ export class GamePiece extends Object3D {
     this._matchKeySequence = [1, 2, 0, 3];
   }
 
-  public StopTweens(): void {
+  public StopTweens(preserveLock = false): void {
     this._removeTween?.stop();
     this._levelChangeTween?.stop();
     this._lockTween?.stop();
     if (this._mesh) {
       this._mesh.position.set(0, 0, 0);
       this._mesh.rotation.set(0, 0, 0);
-      this._mesh.scale.set(1, 1, 1);
+      if (!preserveLock) {
+        this._mesh.scale.set(1, 1, 1);
+      }
     }
   }
 
@@ -802,7 +804,7 @@ export class GamePiece extends Object3D {
   }
 
   public ApplyStateSnapshot(snapshot: PieceStateSnapshot): void {
-    this.StopTweens();
+    this.StopTweens(true);
 
     this._isRemoved = snapshot.isRemoved;
     this._matchKeySequence = [...snapshot.matchKeySequence];
@@ -833,7 +835,7 @@ export class GamePiece extends Object3D {
     this.ApplyStateSnapshot(source.GetStateSnapshot());
   }
 
-  public AnimateGravitySlide(startOffsetY: number, duration: number): Tween<{ y: number }> {
+  public AnimateGravitySlide(startOffsetY: number, duration: number, isLocked = true): Tween<{ y: number }> {
     this._removeTween?.stop();
     this._levelChangeTween?.stop();
     this._lockTween?.stop();
@@ -852,15 +854,18 @@ export class GamePiece extends Object3D {
       }
     }
 
+    const scale = isLocked ? 0.8 : 1.0;
+    const opacity = isLocked ? 0.4 : 1.0;
+
     this._mesh.position.set(0, startOffsetY, 0);
     this._mesh.rotation.set(0, 0, 0);
-    this._mesh.scale.set(1, 1, 1);
+    this._mesh.scale.set(scale, scale, scale);
 
     this._pieceMaterials?.forEach((m) => {
       if (m.useBasic) {
-        m.materialBasic.opacity = 1.0;
+        m.materialBasic.opacity = opacity;
       } else {
-        m.materialPhong.opacity = 1.0;
+        m.materialPhong.opacity = opacity;
       }
     });
 
@@ -876,7 +881,14 @@ export class GamePiece extends Object3D {
       .onComplete(() => {
         this._mesh.position.set(0, 0, 0);
         this._mesh.rotation.set(0, 0, 0);
-        this._mesh.scale.set(1, 1, 1);
+        this._mesh.scale.set(scale, scale, scale);
+        this._pieceMaterials?.forEach((m) => {
+          if (m.useBasic) {
+            m.materialBasic.opacity = opacity;
+          } else {
+            m.materialPhong.opacity = opacity;
+          }
+        });
       });
   }
 }

--- a/src/app/game/services/effects-manager.ts
+++ b/src/app/game/services/effects-manager.ts
@@ -254,7 +254,7 @@ export class EffectsManagerService {
     // Stop ongoing removal/scatter tweens and reset mesh position/rotation to local origin
     axle.forEach((wheel) => {
       for (const piece of wheel.children as GamePiece[]) {
-        piece.StopTweens();
+        piece.StopTweens(true);
       }
     });
 
@@ -406,7 +406,7 @@ export class EffectsManagerService {
     });
 
     const tweens: Tween<Record<string, number>>[] = [];
-    const duration = 1600;
+    const duration = 1000;
 
     actionsToAnimate.forEach((action) => {
       if (action.isNewSpawn && action.newMaterial) {
@@ -418,6 +418,7 @@ export class EffectsManagerService {
           action.targetPiece.ApplyStateSnapshot(snap);
         }
       }
+      action.targetPiece.IsMatch = false;
 
       const tween = action.targetPiece.AnimateGravitySlide(action.startOffsetY, duration);
       tweens.push(tween);

--- a/src/app/game/services/interaction-manager.ts
+++ b/src/app/game/services/interaction-manager.ts
@@ -115,6 +115,7 @@ export class InteractionManagerService {
               this.effectsManager.GravityAnimationComplete.pipe(take(1)).subscribe(() => {
                 this.effectsManager.ClearSelectedPieces();
                 this.postProcessingManager.UpdateOutlinePassObjects([]);
+                this.objectManager.ResetIsMatch();
                 this.effectsManager.AnimateLock(this.objectManager.Axle, false);
                 this.LockBoard(false);
               });

--- a/src/app/game/services/object-manager.ts
+++ b/src/app/game/services/object-manager.ts
@@ -230,6 +230,10 @@ export class ObjectManagerService {
     this.audioManager.PlayLevelStart();
   }
 
+  public ResetIsMatch(): void {
+    this._axle.forEach((wheel) => wheel.ResetIsMatch());
+  }
+
   public AnimateLevelComplete(): void {
     // level transition
     this.postProcessingManager.UpdateLevelTransitionPass(this.gameEngine.LevelTransitionType, false);

--- a/src/app/version.ts
+++ b/src/app/version.ts
@@ -1,2 +1,2 @@
 // Generated automatically during build
-export const APP_VERSION = 'v2026.08.12.1608';
+export const APP_VERSION = 'v2026.08.12.1208';


### PR DESCRIPTION
  ## Summary of Changes

    ### 🧹 Code Quality & Linting
    - **Strict Typing**: Replaced `any` casts with proper TypeScript interfaces (`LevelDialogData`,
  `TextGeometryParameters`, `Tween<Record<string, number>>`, `MatDialogRef`).
    - **ESLint Compliance**: Converted indexed `for` loops to `for-of` / `forEach`, removed unused
  imports/variables, and fixed empty method signatures.
    - **Spec Updates**: Updated test specs (`game-menu.spec.ts`, `user-settings.spec.ts`, `save-game.spec.
  ts`) to use dependency injection and bracket property access without disabling type safety.

    ### ⚙️ CI/CD & Husky Setup
    - **Vercel Build Fix**: Updated `package.json` `prepare` script to `test -d .git && husky || true` and
  added `husky` to `devDependencies` to prevent `command not found (127)` errors during deployment.
    - **Pre-commit Hook**: Standardized `.husky/pre-commit` to format, stage, lint, and run unit tests in
  single-run mode (`npm test -- --watch=false`).

    ### 🎮 Gravity & Lock Animation Polish
    - **Smooth Gravity Slide & Unlock**: Preserved locked visual state (`scale 0.8`, `opacity 0.4`) on
  stationary and incoming blocks during `AnimateGravitySlide`.
    - **Synchronized Board Pulse**: Cleared `IsMatch` flags on newly landed blocks so calling
  `AnimateLock(axle, false)` after gravity completes cleanly unlocks all game blocks together without
  visual snapping or flashing.