### PR TITLE
   fix(game): fix power move rendering and interaction with gravity

### DIFF
--- a/src/app/game/models/game-piece/game-piece.spec.ts
+++ b/src/app/game/models/game-piece/game-piece.spec.ts
@@ -1,7 +1,58 @@
 import { GamePiece } from './game-piece';
+import { PowerMoveType } from '../power-move-type';
+import { LevelGeometryType } from '../../level-geometry-type';
 
 describe('GamePiece', () => {
   it('should create an instance', () => {
     expect(new GamePiece(0, 0, 0, 0)).toBeTruthy();
+  });
+
+  it('should initialize power move correctly on PowerMoveAdd', () => {
+    const piece = new GamePiece(0, 0, 0, 0);
+    piece.PowerMoveAdd(PowerMoveType.HorizontalRight, 0xff0000, false);
+
+    expect(piece.IsPowerMove).toBe(true);
+    expect(piece.IsRemoved).toBe(false);
+    expect(piece.PowerMoveType).toBe(PowerMoveType.HorizontalRight);
+    expect(piece.PowerMove).toBeTruthy();
+    expect(piece.PowerMove.PowerMoveColor).toBe(0xff0000);
+  });
+
+  it('should capture and restore power move in state snapshot', () => {
+    const sourcePiece = new GamePiece(0, 0, 0, 0);
+    sourcePiece.PowerMoveAdd(PowerMoveType.VerticalUp, 0x00ff00, false);
+
+    const snapshot = sourcePiece.GetStateSnapshot();
+    expect(snapshot.isPowerMove).toBe(true);
+    expect(snapshot.powerMoveType).toBe(PowerMoveType.VerticalUp);
+    expect(snapshot.powerMoveColor).toBe(0x00ff00);
+
+    const targetPiece = new GamePiece(0, 0, 0, 0);
+    targetPiece.ApplyStateSnapshot(snapshot);
+
+    expect(targetPiece.IsPowerMove).toBe(true);
+    expect(targetPiece.IsRemoved).toBe(false);
+    expect(targetPiece.PowerMoveType).toBe(PowerMoveType.VerticalUp);
+    expect(targetPiece.PowerMove?.PowerMoveColor).toBe(0x00ff00);
+  });
+
+  it('should update SlideOffsetY during AnimateGravitySlide on a power move piece', () => {
+    const piece = new GamePiece(0, 0, 0, 0);
+    piece.PowerMoveAdd(PowerMoveType.HorizontalLeft, 0x0000ff, false);
+
+    const tween = piece.AnimateGravitySlide(10, 500);
+    expect(piece.PowerMove.SlideOffsetY).toBe(10);
+    expect(piece.IsRemoved).toBe(false);
+    expect(tween).toBeTruthy();
+  });
+
+  it('should clean up power move on Reset', () => {
+    const piece = new GamePiece(0, 0, 0, 0);
+    piece.PowerMoveAdd(PowerMoveType.HorizontalMix, 0xffff00, false);
+    expect(piece.IsPowerMove).toBe(true);
+
+    piece.Reset(LevelGeometryType.Cube);
+    expect(piece.IsPowerMove).toBe(false);
+    expect(piece.PowerMove).toBeFalsy();
   });
 });

--- a/src/app/game/models/game-piece/game-piece.ts
+++ b/src/app/game/models/game-piece/game-piece.ts
@@ -30,6 +30,7 @@ export interface PieceStateSnapshot {
   pieceGeometryType: LevelGeometryType;
   isPowerMove: boolean;
   powerMoveType?: PowerMoveType;
+  powerMoveColor?: number;
 }
 
 export class GamePiece extends Object3D {
@@ -275,6 +276,7 @@ export class GamePiece extends Object3D {
       this._isPowerMove = false;
       this.remove(this._powerMove.PowerMoveMesh);
       this._powerMove?.Dispose();
+      this._powerMove = undefined as unknown as PowerMove;
     }
 
     this._flipTurns = 0;
@@ -302,7 +304,10 @@ export class GamePiece extends Object3D {
     }
   }
 
-  public UpdateMaterials(pieceMaterials: PieceMaterials): void {
+  public UpdateMaterials(pieceMaterials?: PieceMaterials): void {
+    if (!pieceMaterials?.materials) {
+      return;
+    }
     this._pieceMaterials = pieceMaterials.materials;
 
     let target: PieceSideMaterial;
@@ -317,15 +322,19 @@ export class GamePiece extends Object3D {
 
       case LevelGeometryType.Cylinder:
         target = this._pieceMaterials[this._matchKeySequence[0]];
-        targetMaterial = target.useBasic ? target.materialBasic : target.materialPhong;
-        // cylinder side, top, bottom
-        this._meshCylinder.material = [targetMaterial, ...this._cylinderEndCapMaterials];
+        if (target) {
+          targetMaterial = target.useBasic ? target.materialBasic : target.materialPhong;
+          // cylinder side, top, bottom
+          this._meshCylinder.material = [targetMaterial, ...this._cylinderEndCapMaterials];
+        }
         break;
 
       case LevelGeometryType.Dodecahedron:
         target = this._pieceMaterials[this._matchKeySequence[0]];
-        targetMaterial = target.useBasic ? target.materialBasic : target.materialPhong;
-        this._meshDodecahedron.material = targetMaterial;
+        if (target) {
+          targetMaterial = target.useBasic ? target.materialBasic : target.materialPhong;
+          this._meshDodecahedron.material = targetMaterial;
+        }
         break;
     }
 
@@ -767,28 +776,61 @@ export class GamePiece extends Object3D {
 
   // only 1 instance of power move; when the power move is selected, the
   //  state returns to removed
-  public PowerMoveAdd(moveType: PowerMoveType, color?: number): void {
-    // prevent interaction with power move until animation is complete
-    this._isRemoved = true;
+  public PowerMoveAdd(moveType: PowerMoveType, color?: number, isIntro = true): void {
+    this._removeTween?.stop();
+    this._isRemoved = false;
+    this._isPowerMove = true;
     this._matchKey = 0;
     this._powerMoveType = moveType;
 
-    this._powerMove = new PowerMove(moveType, color);
+    // Completely hide base mesh geometries so they do not render or write to depth buffer
+    if (this._meshCube) this._meshCube.visible = false;
+    if (this._meshCylinder) this._meshCylinder.visible = false;
+    if (this._meshDodecahedron) this._meshDodecahedron.visible = false;
+    if (this._mesh) {
+      this._mesh.visible = false;
+      this._mesh.position.set(0, 0, 0);
+      this._mesh.rotation.set(0, 0, 0);
+      this._mesh.scale.set(1, 1, 1);
+    }
+
+    this._pieceMaterials?.forEach((m) => {
+      if (m.useBasic) {
+        m.materialBasic.opacity = 0;
+      } else {
+        m.materialPhong.opacity = 0;
+      }
+    });
+
+    if (this._powerMove) {
+      this.remove(this._powerMove.PowerMoveMesh);
+      this._powerMove.Dispose();
+    }
+
+    this._powerMove = new PowerMove(moveType, color, isIntro);
     this.add(this._powerMove.PowerMoveMesh);
-    this._powerMove
-      .AnimateIntro()
-      .pipe(take(1))
-      .subscribe(() => {
-        // animation is complete
-        this._isRemoved = false;
-        this._isPowerMove = true;
-      });
+
+    if (isIntro) {
+      this._powerMove
+        .AnimateIntro()
+        .pipe(take(1))
+        .subscribe(() => {
+          this._isRemoved = false;
+          this._isPowerMove = true;
+        });
+    }
   }
 
   public PowerMoveRemove(): void {
     this._isRemoved = true;
     this._isPowerMove = false;
-    this._powerMove.Remove();
+    this._powerMove?.Remove();
+    if (this._meshCube) this._meshCube.visible = false;
+    if (this._meshCylinder) this._meshCylinder.visible = false;
+    if (this._meshDodecahedron) this._meshDodecahedron.visible = false;
+    if (this._mesh) {
+      this._mesh.visible = false;
+    }
   }
 
   public GetStateSnapshot(): PieceStateSnapshot {
@@ -800,6 +842,7 @@ export class GamePiece extends Object3D {
       pieceGeometryType: this._pieceGeometryType,
       isPowerMove: this._isPowerMove,
       powerMoveType: this._powerMoveType,
+      powerMoveColor: this._powerMove?.PowerMoveColor,
     };
   }
 
@@ -809,25 +852,34 @@ export class GamePiece extends Object3D {
     this._isRemoved = snapshot.isRemoved;
     this._matchKeySequence = [...snapshot.matchKeySequence];
     this.SetGeometryType(snapshot.pieceGeometryType);
-    this.UpdateMaterials({ materials: snapshot.pieceMaterials });
+    if (snapshot.pieceMaterials) {
+      this.UpdateMaterials({ materials: snapshot.pieceMaterials });
+    }
     this._matchKey = snapshot.matchKey;
 
-    this._pieceMaterials?.forEach((m) => {
-      if (m.useBasic) {
-        m.materialBasic.opacity = snapshot.isRemoved ? 0 : 1.0;
-      } else {
-        m.materialPhong.opacity = snapshot.isRemoved ? 0 : 1.0;
-      }
-    });
-
-    // copy power move if present
+    // clean up existing power move if present
     if (this._powerMove) {
       this._isPowerMove = false;
       this.remove(this._powerMove.PowerMoveMesh);
       this._powerMove?.Dispose();
+      this._powerMove = undefined as unknown as PowerMove;
     }
+
     if (snapshot.isPowerMove && snapshot.powerMoveType !== undefined) {
-      this.PowerMoveAdd(snapshot.powerMoveType);
+      this.PowerMoveAdd(snapshot.powerMoveType, snapshot.powerMoveColor, false);
+    } else {
+      this._isPowerMove = false;
+      if (this._mesh) {
+        this._mesh.visible = !snapshot.isRemoved;
+      }
+      const baseOpacity = snapshot.isRemoved ? 0 : 1.0;
+      this._pieceMaterials?.forEach((m) => {
+        if (m.useBasic) {
+          m.materialBasic.opacity = baseOpacity;
+        } else {
+          m.materialPhong.opacity = baseOpacity;
+        }
+      });
     }
   }
 
@@ -857,6 +909,47 @@ export class GamePiece extends Object3D {
     const scale = isLocked ? 0.8 : 1.0;
     const opacity = isLocked ? 0.4 : 1.0;
 
+    const delta = { y: startOffsetY };
+    const target = { y: 0 };
+
+    if (this._isPowerMove && this._powerMove) {
+      // Keep base piece mesh completely invisible for power move pieces
+      if (this._meshCube) this._meshCube.visible = false;
+      if (this._meshCylinder) this._meshCylinder.visible = false;
+      if (this._meshDodecahedron) this._meshDodecahedron.visible = false;
+      if (this._mesh) {
+        this._mesh.visible = false;
+        this._mesh.position.set(0, 0, 0);
+        this._mesh.rotation.set(0, 0, 0);
+      }
+      this._pieceMaterials?.forEach((m) => {
+        if (m.useBasic) {
+          m.materialBasic.opacity = 0;
+        } else {
+          m.materialPhong.opacity = 0;
+        }
+      });
+
+      this._powerMove.SlideOffsetY = startOffsetY;
+
+      return new Tween(delta, mainTweenGroup)
+        .to(target, duration)
+        .easing(Easing.Bounce.Out)
+        .onUpdate(() => {
+          if (this._powerMove) {
+            this._powerMove.SlideOffsetY = delta.y;
+          }
+        })
+        .onComplete(() => {
+          if (this._powerMove) {
+            this._powerMove.SlideOffsetY = 0;
+          }
+        });
+    }
+
+    if (this._mesh) {
+      this._mesh.visible = true;
+    }
     this._mesh.position.set(0, startOffsetY, 0);
     this._mesh.rotation.set(0, 0, 0);
     this._mesh.scale.set(scale, scale, scale);
@@ -868,9 +961,6 @@ export class GamePiece extends Object3D {
         m.materialPhong.opacity = opacity;
       }
     });
-
-    const delta = { y: startOffsetY };
-    const target = { y: 0 };
 
     return new Tween(delta, mainTweenGroup)
       .to(target, duration)

--- a/src/app/game/models/game-piece/power-move.ts
+++ b/src/app/game/models/game-piece/power-move.ts
@@ -25,6 +25,15 @@ export class PowerMove {
   private _spinTween?: Tween<Record<string, number>>;
   private _bounceTween?: Tween<Record<string, number>>;
 
+  private _slideOffsetY = 0;
+  get SlideOffsetY(): number {
+    return this._slideOffsetY;
+  }
+  set SlideOffsetY(offset: number) {
+    this._slideOffsetY = offset;
+    this._root.position.y = this._slideOffsetY;
+  }
+
   private _powerMoveColor!: number;
   get PowerMoveColor(): number {
     return this._powerMoveColor;
@@ -36,16 +45,15 @@ export class PowerMove {
 
   private static _geometryCache = new Map<PowerMoveType, BufferGeometry>();
 
-  constructor(moveType: PowerMoveType, arg2?: unknown, color?: number) {
-    const actualColor = typeof arg2 === 'number' ? arg2 : color;
-    this._powerMoveColor = actualColor || RAINBOW_COLOR_ARRAY[MathUtils.randInt(0, RAINBOW_COLOR_ARRAY.length - 1)];
+  constructor(moveType: PowerMoveType, color?: number, isIntro = true) {
+    this._powerMoveColor = color || RAINBOW_COLOR_ARRAY[MathUtils.randInt(0, RAINBOW_COLOR_ARRAY.length - 1)];
 
     const mainMaterial = new MeshPhongMaterial({
       color: this._powerMoveColor,
       emissive: this._powerMoveColor,
       emissiveIntensity: 0.35,
       transparent: true,
-      opacity: 0.0,
+      opacity: isIntro ? 0.0 : 0.85,
       shininess: 60,
     });
     this._materials.push(mainMaterial);
@@ -61,7 +69,7 @@ export class PowerMove {
         emissive: this._powerMoveColor,
         emissiveIntensity: 0.5,
         transparent: true,
-        opacity: 0.0,
+        opacity: isIntro ? 0.0 : 0.85,
       });
       this._materials.push(ringMaterial);
 
@@ -78,7 +86,12 @@ export class PowerMove {
       this._root = mesh;
     }
 
-    this._root.scale.set(0.001, 0.001, 0.001);
+    if (isIntro) {
+      this._root.scale.set(0.001, 0.001, 0.001);
+    } else {
+      this._root.scale.set(1.0, 1.0, 1.0);
+      this.startBounceTween();
+    }
   }
 
   private static getGeometryForType(moveType: PowerMoveType): BufferGeometry {
@@ -238,19 +251,25 @@ export class PowerMove {
         })
         .start();
 
-      let animTime = 0;
-      this._bounceTween = new Tween({}, mainTweenGroup)
-        .repeat(Infinity)
-        .onUpdate(() => {
-          animTime += 0.05;
-          this._root.rotation.y += 0.008;
-          this._root.position.y = Math.sin(animTime) * 0.15;
-        })
-        .start();
+      this.startBounceTween();
     });
   }
 
+  private startBounceTween(): void {
+    this._bounceTween?.stop();
+    let animTime = 0;
+    this._bounceTween = new Tween({}, mainTweenGroup)
+      .repeat(Infinity)
+      .onUpdate(() => {
+        animTime += 0.05;
+        this._root.rotation.y += 0.008;
+        this._root.position.y = this._slideOffsetY + Math.sin(animTime) * 0.15;
+      })
+      .start();
+  }
+
   public Remove(): void {
+    this._bounceTween?.stop();
     const delta = { s: this._root.scale.x, o: 0.85 };
     const target = { s: 4.0, o: 0.0 };
     new Tween(delta, mainTweenGroup)

--- a/src/app/game/services/effects-manager.spec.ts
+++ b/src/app/game/services/effects-manager.spec.ts
@@ -54,4 +54,15 @@ describe('EffectsManager', () => {
     service.AnimateLevelChangeAnimation(wheels, [0], camera, light, true);
     expect(animationState).toBe(true);
   });
+
+  it('should handle AnimateGravity with game wheels and complete', () => {
+    let completed = false;
+    service.GravityAnimationComplete.subscribe(() => {
+      completed = true;
+    });
+
+    const wheels = [new GameWheel(0, []), new GameWheel(1, [])];
+    service.AnimateGravity(wheels, GravityType.Down);
+    expect(completed).toBe(true);
+  });
 });

--- a/src/app/game/services/effects-manager.ts
+++ b/src/app/game/services/effects-manager.ts
@@ -297,7 +297,7 @@ export class EffectsManagerService {
     for (const col of columns) {
       const removedIndices: number[] = [];
       col.forEach((p, idx) => {
-        if (p.IsRemoved) removedIndices.push(idx);
+        if (p.IsRemoved && !p.IsPowerMove) removedIndices.push(idx);
       });
 
       if (removedIndices.length === 0) continue;
@@ -310,7 +310,7 @@ export class EffectsManagerService {
 
         const nonRemovedAbove: GamePiece[] = [];
         for (let i = lowestRemoved; i < numWheels; i++) {
-          if (!col[i].IsRemoved) {
+          if (!col[i].IsRemoved || col[i].IsPowerMove) {
             nonRemovedAbove.push(col[i]);
           }
         }
@@ -349,7 +349,7 @@ export class EffectsManagerService {
 
         const nonRemovedBelow: GamePiece[] = [];
         for (let i = 0; i <= highestRemoved; i++) {
-          if (!col[i].IsRemoved) {
+          if (!col[i].IsRemoved || col[i].IsPowerMove) {
             nonRemovedBelow.push(col[i]);
           }
         }

--- a/src/app/game/services/interaction-manager.ts
+++ b/src/app/game/services/interaction-manager.ts
@@ -70,8 +70,6 @@ export class InteractionManagerService {
       // selection animation complete
       if (selectionMode) {
         if (this._matchingPieces.length >= MINIMUM_MATCH_COUNT) {
-          // initiate the removal animation
-          this.effectsManager.AnimateRemove(this._matchingPieces);
           // update score
           this.scoringManager.UpdateScore(this._matchingPieces.length, this.scoringManager.LevelComplete);
           // long match audio
@@ -86,6 +84,7 @@ export class InteractionManagerService {
 
           // level completed
           if (this.scoringManager.LevelComplete) {
+            this.effectsManager.AnimateRemove(this._matchingPieces);
             this.audioManager.PlayLevelComplete();
             this.hapticsManager.LevelCompletePulse();
             this.objectManager.AnimateLevelComplete();
@@ -94,6 +93,7 @@ export class InteractionManagerService {
             this.objectManager.LevelCompleted.next(false);
           } else {
             // power move
+            let powerMovePiece: GamePiece | undefined;
             const powerMoveTarget =
               this.scoringManager.Level >= DIFFICULTY_TIER_2 ? MINIMUM_MATCH_COUNT : MINIMUM_MATCH_COUNT + 1;
             if (this._matchingPieces.length >= powerMoveTarget) {
@@ -105,10 +105,17 @@ export class InteractionManagerService {
                 if (isDevMode()) {
                   console.info('  ', PowerMoveType[moveType]);
                 }
+                powerMovePiece = this._matchingPieces[0];
                 this.audioManager.PlayAudio(AudioType.POWER_MOVE_APPEAR);
-                this.objectManager.GamePiecePowerMove(this._matchingPieces[0], moveType);
+                this.objectManager.GamePiecePowerMove(powerMovePiece, moveType);
               }
             }
+
+            // Animate removal of matched pieces (excluding the piece that became a power move)
+            const piecesToRemove = powerMovePiece
+              ? this._matchingPieces.filter((p) => p !== powerMovePiece)
+              : this._matchingPieces;
+            this.effectsManager.AnimateRemove(piecesToRemove);
 
             // Gravity animation
             if (this.gameEngine.GravityType !== GravityType.None) {
@@ -124,6 +131,7 @@ export class InteractionManagerService {
             } else {
               this.effectsManager.ClearSelectedPieces();
               this.postProcessingManager.UpdateOutlinePassObjects([]);
+              this.objectManager.ResetIsMatch();
               this.effectsManager.AnimateLock(this.objectManager.Axle, false);
               this.LockBoard(false);
             }

--- a/src/app/version.ts
+++ b/src/app/version.ts
@@ -1,2 +1,2 @@
 // Generated automatically during build
-export const APP_VERSION = 'v2026.08.12.1208';
+export const APP_VERSION = 'v2026.08.12.1808';


### PR DESCRIPTION
    ## Summary
    Fixes an issue where column gravity and removal animations were preventing power move pieces from
  displaying and being playable.

    ## Key Changes
    - **GamePiece**:
      - Sets `_isPowerMove = true` and `_isRemoved = false` upon creation to treat power moves as active
  occupants.
      - Explicitly hides base mesh geometries (`_mesh.visible = false`) to eliminate depth buffer occlusion
  ("transparent box").
      - Preserves `powerMoveColor` across `PieceStateSnapshot` restorations and routes gravity slide
  offsets to `PowerMove.SlideOffsetY`.
    - **PowerMove**:
      - Added `SlideOffsetY` integration to `_bounceTween` for gravity slides.
      - Added support for instant rendering mode when transferred across wheels.
    - **EffectsManager**:
      - Excluded power move pieces from empty column removal indices during gravity calculations.
    - **InteractionManager**:
      - Only animates removal on matched pieces that are not transforming into power moves.
      - Ensures `ResetIsMatch()` is called in all gravity branches.
    - **Unit Tests**:
      - Added test coverage in `game-piece.spec.ts` and `effects-manager.spec.ts`.

    ## Verification
    - All automated unit tests passing (`npm test`).
    - Build passing inside DevContainer.
    - Verified manual gameplay in gravity `None`, `Down`, `Up`, and `Mix` modes.
