### PR TITLE
feat(game): award bonus moves and restore splash banner for multi-pow…

### DIFF
--- a/src/app/game/services/interaction-manager.ts
+++ b/src/app/game/services/interaction-manager.ts
@@ -279,6 +279,7 @@ export class InteractionManagerService {
     this.scoringManager.UpdateMoveCount();
     const moveType = targetGamePiece.PowerMoveType;
     targetGamePiece.PowerMoveRemove();
+    this.scoringManager.UpdatePowerMoveBonus(powerMoveGamePieces.length, moveType);
 
     // power move could have been the player's last move
     if (this.scoringManager.GameOver) {
@@ -287,7 +288,6 @@ export class InteractionManagerService {
       this.audioManager.StopAudio(AudioType.PIECE_MOVE_REMAINING_PANIC);
       this.LockBoard(false);
     } else {
-      this.scoringManager.UpdatePowerMoveBonus(powerMoveGamePieces.length, moveType);
       this.hapticsManager.PowerMovePulse();
 
       if (moveType === PowerMoveType.Bomb) {
@@ -334,6 +334,8 @@ export class InteractionManagerService {
       // panic
       if (this.scoringManager.PlayerMoves === MOVES_REMAINING_COUNT_PANIC) {
         this.audioManager.PlayAudio(AudioType.PIECE_MOVE_REMAINING_PANIC, false, true);
+      } else if (this.scoringManager.PlayerMoves > MOVES_REMAINING_COUNT_PANIC) {
+        this.audioManager.StopAudio(AudioType.PIECE_MOVE_REMAINING_PANIC);
       }
     }
 

--- a/src/app/game/services/scoring-manager.spec.ts
+++ b/src/app/game/services/scoring-manager.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { ScoringManagerService } from './scoring-manager';
 import { TextManagerService } from '../text/services/text-manager';
+import { PowerMoveType } from '../models/power-move-type';
 
 class MockTextManagerService {
   ShowText = () => undefined;
@@ -99,5 +100,71 @@ describe('ScoringManagerService', () => {
     expect(service.LevelProgress).toBe(60);
     expect(service.LevelPieceTarget).toBe(10);
     expect(service.Score).toBe(1500);
+  });
+
+  it('should calculate bonus correctly for a single power move without awarding extra moves', () => {
+    const textManager = TestBed.inject(TextManagerService);
+    let capturedMessage: string[] = [];
+    textManager.ShowText = (msg: string[]) => {
+      capturedMessage = msg;
+    };
+
+    const initialMoves = service.PlayerMoves;
+    const initialScore = service.Score;
+
+    service.UpdatePowerMoveBonus(0, PowerMoveType.HorizontalRight);
+
+    expect(service.Score).toBe(initialScore + 50);
+    expect(service.PlayerMoves).toBe(initialMoves);
+    expect(service.LevelStats.moveCountEarned).toBe(0);
+    expect(capturedMessage).toEqual(['Spin right!', '+50 Points']);
+  });
+
+  it('should calculate bonus and award +1 move for multi-power move with 1 additional power move', () => {
+    const textManager = TestBed.inject(TextManagerService);
+    let capturedMessage: string[] = [];
+    textManager.ShowText = (msg: string[]) => {
+      capturedMessage = msg;
+    };
+
+    let movesChangeEmitted: boolean | undefined;
+    service.MovesChange.subscribe((increase) => {
+      movesChangeEmitted = increase;
+    });
+
+    const initialMoves = service.PlayerMoves;
+    const initialScore = service.Score;
+
+    service.UpdatePowerMoveBonus(1, PowerMoveType.HorizontalRight);
+
+    expect(service.Score).toBe(initialScore + 100);
+    expect(service.PlayerMoves).toBe(initialMoves + 1);
+    expect(service.LevelStats.moveCountEarned).toBe(1);
+    expect(movesChangeEmitted).toBe(true);
+    expect(capturedMessage).toEqual(['Multi-Power!', '+1 Move', '+100 Points']);
+  });
+
+  it('should calculate bonus and award +2 moves for multi-power move with 2 additional power moves', () => {
+    const textManager = TestBed.inject(TextManagerService);
+    let capturedMessage: string[] = [];
+    textManager.ShowText = (msg: string[]) => {
+      capturedMessage = msg;
+    };
+
+    let movesChangeEmitted: boolean | undefined;
+    service.MovesChange.subscribe((increase) => {
+      movesChangeEmitted = increase;
+    });
+
+    const initialMoves = service.PlayerMoves;
+    const initialScore = service.Score;
+
+    service.UpdatePowerMoveBonus(2, PowerMoveType.VerticalUp);
+
+    expect(service.Score).toBe(initialScore + 150);
+    expect(service.PlayerMoves).toBe(initialMoves + 2);
+    expect(service.LevelStats.moveCountEarned).toBe(2);
+    expect(movesChangeEmitted).toBe(true);
+    expect(capturedMessage).toEqual(['Multi-Power!', '+2 Moves', '+150 Points']);
   });
 });

--- a/src/app/game/services/scoring-manager.ts
+++ b/src/app/game/services/scoring-manager.ts
@@ -154,12 +154,20 @@ export class ScoringManagerService {
     let usePowerMoveBonus = this.level() * POWER_MOVE_USE_SCORE_MULTIPLIER;
     if (additionalMoveCount) {
       usePowerMoveBonus *= additionalMoveCount + 1;
+      this.playerMoves.update((m) => m + additionalMoveCount);
+      this._levelStats.moveCountEarned += additionalMoveCount;
+      this.MovesChange.next(true);
     }
     this.score.update((s) => s + usePowerMoveBonus);
 
-    const info = PowerMoveLabel.find((p) => p.type === moveType);
-    const label = info?.label ? `${info.label}!` : additionalMoveCount ? 'Multi-Power!' : 'Power Move!';
-    this.textTextManager.ShowText([`${label}`, `+${usePowerMoveBonus} Points`], this.textColor, true);
+    if (additionalMoveCount > 0) {
+      const moveText = additionalMoveCount === 1 ? '+1 Move' : `+${additionalMoveCount} Moves`;
+      this.textTextManager.ShowText(['Multi-Power!', moveText, `+${usePowerMoveBonus} Points`], this.textColor, true);
+    } else {
+      const info = PowerMoveLabel.find((p) => p.type === moveType);
+      const label = info?.label ? `${info.label}!` : 'Power Move!';
+      this.textTextManager.ShowText([label, `+${usePowerMoveBonus} Points`], this.textColor, true);
+    }
   }
 
   public RestartGame(): void {


### PR DESCRIPTION
   ## Summary
    - **Multi-Power Moves**: Awards `+1` bonus move per extra power move cleared simultaneously
  (`playerMoves`, `moveCountEarned`, and `MovesChange` notification).
    - **Splash Text**: Restores the `"Multi-Power!"` banner and adds a sequential `"+X Move(s)"` line
  before the bonus points text.
    - **Game-Over Flow**: Evaluates bonus moves before checking `GameOver` and turns off panic audio if
  remaining moves exceed the panic threshold.
    - **Tests**: Adds unit tests covering single vs multi-power score calculations, move awards, and splash
  text queues.