### PR TITLE
 refactor(game): standardize difficulty tiers, progression constants,…

### DIFF
--- a/src/app/game/game-constants.ts
+++ b/src/app/game/game-constants.ts
@@ -33,9 +33,21 @@ export const PERFECT_MATCH_SCORE_MULTIPLIER = 100;
 export const MOVES_REMAINING_COUNT_WARNING = 3;
 export const MOVES_REMAINING_COUNT_DANGER = 2;
 export const MOVES_REMAINING_COUNT_PANIC = 2;
-export const LEVEL_START_OTHER_GEOMETRIES = 3;
-export const LEVEL_START_CYLINDER = 4;
-export const LEVEL_START_DODECAHEDRON = 7;
+export const LEVEL_START_CYLINDER = 7;
+export const LEVEL_START_DODECAHEDRON = 12;
+
+// Feature Unlock Levels
+export const POWER_MOVE_START_LEVEL = 3;
+export const POWER_MOVE_START_VERTICAL = 6;
+export const POWER_MOVE_START_MIX = 9;
+export const POWER_MOVE_START_BOMB = 12;
+export const GRAVITY_START_DOWN = 6;
+export const GRAVITY_START_UP = 10;
+export const GRAVITY_START_MIX = 14;
+export const MATERIAL_START_COLOR = 3;
+export const MATERIAL_START_BUMP = 5;
+export const MATERIAL_START_EMOJI = 9;
+
 export const DIFFICULTY_TIER_1 = 10;
 export const DIFFICULTY_TIER_2 = 20;
 export const DIFFICULTY_TIER_3 = 30;

--- a/src/app/game/services/game-engine.spec.ts
+++ b/src/app/game/services/game-engine.spec.ts
@@ -83,10 +83,10 @@ describe('GameEngineService', () => {
       expect(l9Materials.has(LevelMaterialType.Emoji)).toBe(true);
     });
 
-    it('should initialize level 3 gravity to None or Down', () => {
+    it('should initialize level 6 gravity to None or Down', () => {
       const foundTypes = new Set<GravityType>();
       for (let i = 0; i < 50; i++) {
-        service.InitLevelTypes(3);
+        service.InitLevelTypes(6);
         foundTypes.add(service.GravityType);
       }
       for (const t of foundTypes) {
@@ -94,36 +94,36 @@ describe('GameEngineService', () => {
       }
     });
 
-    it('should initialize level 7+ gravity to None, Down, Up, or Mix', () => {
+    it('should initialize level 14+ gravity to None, Down, Up, or Mix', () => {
       const foundTypes = new Set<GravityType>();
       for (let i = 0; i < 100; i++) {
-        service.InitLevelTypes(7);
+        service.InitLevelTypes(14);
         foundTypes.add(service.GravityType);
       }
       expect(foundTypes.size).toBeGreaterThan(1);
     });
 
-    it('should keep Cube geometry for levels 1 to 3, introduce Cylinder at level 4, and Dodecahedron at level 7+', () => {
+    it('should keep Cube geometry for levels 1 to 6, introduce Cylinder at level 7, and Dodecahedron at level 12+', () => {
       for (let i = 0; i < 30; i++) {
-        service.InitLevelTypes(3);
+        service.InitLevelTypes(6);
         expect(service.LevelGeometryType).toBe(LevelGeometryType.Cube);
       }
 
-      const l4Geos = new Set<LevelGeometryType>();
-      for (let i = 0; i < 50; i++) {
-        service.InitLevelTypes(4);
-        l4Geos.add(service.LevelGeometryType);
-      }
-      expect(l4Geos.has(LevelGeometryType.Cube)).toBe(true);
-      expect(l4Geos.has(LevelGeometryType.Cylinder)).toBe(true);
-      expect(l4Geos.has(LevelGeometryType.Dodecahedron)).toBe(false);
-
       const l7Geos = new Set<LevelGeometryType>();
-      for (let i = 0; i < 100; i++) {
+      for (let i = 0; i < 50; i++) {
         service.InitLevelTypes(7);
         l7Geos.add(service.LevelGeometryType);
       }
-      expect(l7Geos.has(LevelGeometryType.Dodecahedron)).toBe(true);
+      expect(l7Geos.has(LevelGeometryType.Cube)).toBe(true);
+      expect(l7Geos.has(LevelGeometryType.Cylinder)).toBe(true);
+      expect(l7Geos.has(LevelGeometryType.Dodecahedron)).toBe(false);
+
+      const l12Geos = new Set<LevelGeometryType>();
+      for (let i = 0; i < 100; i++) {
+        service.InitLevelTypes(12);
+        l12Geos.add(service.LevelGeometryType);
+      }
+      expect(l12Geos.has(LevelGeometryType.Dodecahedron)).toBe(true);
     });
 
     it('should restore gravity type in RestoreLevelTypes', () => {
@@ -157,7 +157,7 @@ describe('GameEngineService', () => {
 
     it('should constrain Dodecahedron geometry levels to ColorBumpShape, Color, or ColorBumpMaterial', () => {
       for (let i = 0; i < 100; i++) {
-        service.InitLevelTypes(7);
+        service.InitLevelTypes(12);
         if (service.LevelGeometryType === LevelGeometryType.Dodecahedron) {
           expect([
             LevelMaterialType.ColorBumpShape,

--- a/src/app/game/services/game-engine.ts
+++ b/src/app/game/services/game-engine.ts
@@ -2,11 +2,20 @@ import { Injectable, isDevMode } from '@angular/core';
 import {
   DECIMAL_COMPARISON_TOLERANCE,
   DIFFICULTY_TIER_2,
-  DIFFICULTY_TIER_3,
+  GRAVITY_START_DOWN,
+  GRAVITY_START_MIX,
+  GRAVITY_START_UP,
   LEVEL_START_CYLINDER,
   LEVEL_START_DODECAHEDRON,
+  MATERIAL_START_BUMP,
+  MATERIAL_START_COLOR,
+  MATERIAL_START_EMOJI,
   MINIMUM_MATCH_COUNT,
   PLAYABLE_TEXTURE_COUNT,
+  POWER_MOVE_START_BOMB,
+  POWER_MOVE_START_LEVEL,
+  POWER_MOVE_START_MIX,
+  POWER_MOVE_START_VERTICAL,
 } from '../game-constants';
 import { LevelGeometryType } from '../level-geometry-type';
 import { LevelMaterialType } from '../level-material-type';
@@ -78,12 +87,12 @@ export class GameEngineService {
         LevelMaterialType.ColorBumpMaterial,
       ];
       this._levelMaterialType = dodecahedronMaterials[Math.floor(getRandom() * dodecahedronMaterials.length)];
-    } else if (level <= 2) {
+    } else if (level < MATERIAL_START_COLOR) {
       this._levelMaterialType = LevelMaterialType.ColorBumpShape;
-    } else if (level <= 4) {
+    } else if (level < MATERIAL_START_BUMP) {
       const level4Materials = [LevelMaterialType.ColorBumpShape, LevelMaterialType.Color];
       this._levelMaterialType = level4Materials[Math.floor(getRandom() * level4Materials.length)];
-    } else if (level <= 8) {
+    } else if (level < MATERIAL_START_EMOJI) {
       const level8Materials = [
         LevelMaterialType.ColorBumpShape,
         LevelMaterialType.Color,
@@ -101,12 +110,12 @@ export class GameEngineService {
     }
 
     // gradual gravity type introduction
-    if (level <= 2) {
+    if (level < GRAVITY_START_DOWN) {
       this._gravityType = GravityType.None;
-    } else if (level <= 4) {
+    } else if (level < GRAVITY_START_UP) {
       const gravityOptions = [GravityType.None, GravityType.Down];
       this._gravityType = gravityOptions[Math.floor(getRandom() * gravityOptions.length)];
-    } else if (level <= 6) {
+    } else if (level < GRAVITY_START_MIX) {
       const gravityOptions = [GravityType.None, GravityType.Down, GravityType.Up];
       this._gravityType = gravityOptions[Math.floor(getRandom() * gravityOptions.length)];
     } else {
@@ -145,23 +154,23 @@ export class GameEngineService {
   }
 
   public PowerMoveSelection(level: number): PowerMoveType {
-    // Power moves begin at level 3
-    if (level < 3) {
+    // Power moves begin at POWER_MOVE_START_LEVEL
+    if (level < POWER_MOVE_START_LEVEL) {
       return PowerMoveType.None;
     }
 
-    // Build available power moves based on 3-level progression increments
+    // Build available power moves based on progression increments
     const availableTypes: PowerMoveType[] = [PowerMoveType.HorizontalRight, PowerMoveType.HorizontalLeft];
 
-    if (level >= 6) {
+    if (level >= POWER_MOVE_START_VERTICAL) {
       availableTypes.push(PowerMoveType.VerticalUp, PowerMoveType.VerticalDown);
     }
 
-    if (level >= 9) {
+    if (level >= POWER_MOVE_START_MIX) {
       availableTypes.push(PowerMoveType.HorizontalMix, PowerMoveType.VerticalMix);
     }
 
-    if (level >= 12) {
+    if (level >= POWER_MOVE_START_BOMB) {
       availableTypes.push(PowerMoveType.Bomb);
     }
 
@@ -178,11 +187,8 @@ export class GameEngineService {
       }
     }
 
-    // Up to DIFFICULTY_TIER_3, retain a chance of None
-    const selectionPool: PowerMoveType[] = [...availableTypes];
-    if (level <= DIFFICULTY_TIER_3) {
-      selectionPool.push(PowerMoveType.None);
-    }
+    // Always retain a chance of None
+    const selectionPool: PowerMoveType[] = [...availableTypes, PowerMoveType.None];
 
     const moveType = selectionPool[Math.floor(Math.random() * selectionPool.length)];
 

--- a/src/app/game/services/scoring-manager.spec.ts
+++ b/src/app/game/services/scoring-manager.spec.ts
@@ -203,5 +203,10 @@ describe('ScoringManagerService', () => {
       service.CheckPerfectMatch();
       expect(service.StatsEntries()).toBe(3); // moveCount + pieceCount + perfectMatchBonus
     });
+
+    it('should cap levelPieceTarget at DIFFICULTY_TIER_4 (50) for high levels', () => {
+      service.StartSavedGame(100, 0, 10);
+      expect(service.LevelPieceTarget).toBe(50);
+    });
   });
 });

--- a/src/app/game/services/scoring-manager.ts
+++ b/src/app/game/services/scoring-manager.ts
@@ -2,7 +2,7 @@ import { Injectable, inject, signal } from '@angular/core';
 import { Subject } from 'rxjs';
 import { MathUtils } from 'three';
 import {
-  DIFFICULTY_TIER_3,
+  DIFFICULTY_TIER_4,
   LEVEL_ADDITIVE,
   LONG_MATCH_SCORE_MULTIPLIER,
   MINIMUM_MATCH_COUNT,
@@ -270,8 +270,8 @@ export class ScoringManagerService {
   private initLevelPieceTarget(): void {
     let target = Math.ceil(Math.log2(this.level())) + this.level() + LEVEL_ADDITIVE;
     // cap the number of pieces
-    if (target > DIFFICULTY_TIER_3) {
-      target = DIFFICULTY_TIER_3;
+    if (target > DIFFICULTY_TIER_4) {
+      target = DIFFICULTY_TIER_4;
     }
     this.levelPieceTarget.set(target);
     this.piecesRemaining.set(target);

--- a/src/app/version.ts
+++ b/src/app/version.ts
@@ -1,2 +1,2 @@
 // Generated automatically during build
-export const APP_VERSION = 'v2026.08.16.1008';
+export const APP_VERSION = 'v2026.08.16.1708';


### PR DESCRIPTION

    ## Summary of Changes

    ### 1. Semantic Progression Constants & Cleanup
    - Replaced scattered magic numbers across the game engine with named constants in game-constants.ts:
      - `POWER_MOVE_START_LEVEL = 3`, `POWER_MOVE_START_VERTICAL = 6`, `POWER_MOVE_START_MIX = 9`,
  `POWER_MOVE_START_BOMB = 12`
      - `GRAVITY_START_DOWN = 6`, `GRAVITY_START_UP = 10`, `GRAVITY_START_MIX = 14`
      - `MATERIAL_START_COLOR = 3`, `MATERIAL_START_BUMP = 5`, `MATERIAL_START_EMOJI = 9`
    - Removed unused legacy constant `LEVEL_START_OTHER_GEOMETRIES = 3`.

    ### 2. Geometry & Gravity Progression Tuning
    - **Geometries**:
      - Cylinders now unlock starting at **Level 7** (`LEVEL_START_CYLINDER = 7`, previously 4).
      - Dodecahedrons now unlock starting at **Level 12** (`LEVEL_START_DODECAHEDRON = 12`, previously 7).
    - **Gravity Modes**:
      - Down gravity now introduces at **Level 6** (`GRAVITY_START_DOWN = 6`).
      - Up gravity now introduces at **Level 10** (`GRAVITY_START_UP = 10`).
      - Mix gravity now introduces at **Level 14** (`GRAVITY_START_MIX = 14`).

    ### 3. Power Move Probability & Target Piece Cap
    - **Removed Guaranteed Power Moves**: game-engine.ts now retains `PowerMoveType.None` in the selection
  pool across all levels, keeping power moves probabilistic rather than guaranteed past level 30.
    - **Piece Target Cap**: Increased the level piece target ceiling from 30 to **50 pieces**
  (`DIFFICULTY_TIER_4 = 50`) in scoring-manager.ts.

    ### 4. Tests
    - Updated unit tests in game-engine.spec.ts covering new geometry and gravity milestones.
    - Added a unit test in scoring-manager.spec.ts validating the 50-piece target ceiling at high levels.