### PR TITLE
 feat(analytics): add telemetry for game loop, menus, dialogs, and se…

### DIFF
--- a/src/app/game/components/dialogs/components/game-over/game-over.spec.ts
+++ b/src/app/game/components/dialogs/components/game-over/game-over.spec.ts
@@ -3,11 +3,13 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { vi } from 'vitest';
 
 import { GameOver } from './game-over';
+import { AnalyticsEventType, AnalyticsManagerService } from '../../../../../shared/services/analytics-manager';
 
 describe('GameOver', () => {
   let component: GameOver;
   let fixture: ComponentFixture<GameOver>;
   let mockDialogRef: { close: ReturnType<typeof vi.fn> };
+  let analyticsManager: AnalyticsManagerService;
 
   beforeEach(async () => {
     mockDialogRef = { close: vi.fn() };
@@ -20,30 +22,59 @@ describe('GameOver', () => {
       ],
     }).compileComponents();
 
+    analyticsManager = TestBed.inject(AnalyticsManagerService);
+    vi.spyOn(analyticsManager, 'Log');
+
     fixture = TestBed.createComponent(GameOver);
     component = fixture.componentInstance;
     await fixture.whenStable();
   });
 
-  it('should create and detect level > 1', () => {
+  it('should create and log GameOverDialogViewed and detect level > 1', () => {
     expect(component).toBeTruthy();
     expect(component.isLevelOne()).toBe(false);
+    expect(analyticsManager.Log).toHaveBeenCalledWith(
+      AnalyticsEventType.GameOverDialogViewed,
+      expect.objectContaining({ level: 3, isLevelOne: false }),
+    );
   });
 
-  it('should prompt confirmation on onCloseGameOver when level > 1', () => {
+  it('should prompt confirmation and log GameOverStartOverCTA on onCloseGameOver when level > 1', () => {
     expect(component.confirmStartOver()).toBe(false);
     component.onCloseGameOver();
+    expect(analyticsManager.Log).toHaveBeenCalledWith(
+      AnalyticsEventType.GameOverStartOverCTA,
+      expect.objectContaining({ level: 3, isLevelOne: false }),
+    );
     expect(component.confirmStartOver()).toBe(true);
     expect(mockDialogRef.close).not.toHaveBeenCalled();
   });
 
-  it('should close dialog with startOver: true on confirmed start over', () => {
+  it('should close dialog with startOver: true and log GameOverConfirmStartOverCTA on confirmed start over', () => {
     component.onConfirmStartOver();
+    expect(analyticsManager.Log).toHaveBeenCalledWith(
+      AnalyticsEventType.GameOverConfirmStartOverCTA,
+      expect.objectContaining({ level: 3 }),
+    );
     expect(mockDialogRef.close).toHaveBeenCalledWith(expect.objectContaining({ startOver: true }));
   });
 
-  it('should close dialog with startOver: false on restart level', () => {
+  it('should log GameOverCancelStartOverCTA and reset confirmStartOver on cancel start over', () => {
+    component.confirmStartOver.set(true);
+    component.onCancelStartOver();
+    expect(analyticsManager.Log).toHaveBeenCalledWith(
+      AnalyticsEventType.GameOverCancelStartOverCTA,
+      expect.objectContaining({ level: 3 }),
+    );
+    expect(component.confirmStartOver()).toBe(false);
+  });
+
+  it('should close dialog with startOver: false and log GameOverRestartLevelCTA on restart level', () => {
     component.onCloseRestartLevel();
+    expect(analyticsManager.Log).toHaveBeenCalledWith(
+      AnalyticsEventType.GameOverRestartLevelCTA,
+      expect.objectContaining({ level: 3 }),
+    );
     expect(mockDialogRef.close).toHaveBeenCalledWith(expect.objectContaining({ startOver: false }));
   });
 });

--- a/src/app/game/components/dialogs/components/game-over/game-over.ts
+++ b/src/app/game/components/dialogs/components/game-over/game-over.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectorRef, signal } from '@angular/core';
+import { Component, inject, ChangeDetectorRef, signal, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
@@ -10,6 +10,7 @@ import { MathUtils } from 'three';
 import { GAME_OVER_EMOJI } from '../../../../game-constants';
 import { GameOverData } from './game-over-type';
 import { TextureManagerService } from '../../../../services/texture/texture-manager';
+import { AnalyticsEventType, AnalyticsManagerService } from '../../../../../shared/services/analytics-manager';
 import { HighScores } from '../../../high-scores/high-scores';
 import { ProgressBar } from '../../../../../shared/components/progress-bar/progress-bar';
 
@@ -19,7 +20,7 @@ import { ProgressBar } from '../../../../../shared/components/progress-bar/progr
   templateUrl: './game-over.html',
   styleUrl: './game-over.scss',
 })
-export class GameOver {
+export class GameOver implements OnInit {
   texturesStillLoading = signal<boolean>(true);
   progress = signal<number>(100);
 
@@ -30,6 +31,7 @@ export class GameOver {
   );
 
   private textureManager = inject(TextureManagerService);
+  private analyticsManager = inject(AnalyticsManagerService);
   private dialogRef = inject(MatDialogRef<GameOver>);
   public data: GameOverData = inject(MAT_DIALOG_DATA);
   private destroyRef = inject(DestroyRef);
@@ -51,7 +53,19 @@ export class GameOver {
     this.isLevelOne.set(this.data?.level === 1);
   }
 
+  ngOnInit(): void {
+    this.analyticsManager.Log(AnalyticsEventType.GameOverDialogViewed, {
+      level: this.data?.level,
+      isLevelOne: this.isLevelOne(),
+    });
+  }
+
   onCloseGameOver(): void {
+    this.analyticsManager.Log(AnalyticsEventType.GameOverStartOverCTA, {
+      level: this.data?.level,
+      isLevelOne: this.isLevelOne(),
+    });
+
     if (!this.isLevelOne()) {
       this.confirmStartOver.set(true);
     } else {
@@ -61,15 +75,24 @@ export class GameOver {
   }
 
   onConfirmStartOver(): void {
+    this.analyticsManager.Log(AnalyticsEventType.GameOverConfirmStartOverCTA, {
+      level: this.data?.level,
+    });
     this.data.startOver = true;
     this.dialogRef.close(this.data);
   }
 
   onCancelStartOver(): void {
+    this.analyticsManager.Log(AnalyticsEventType.GameOverCancelStartOverCTA, {
+      level: this.data?.level,
+    });
     this.confirmStartOver.set(false);
   }
 
   onCloseRestartLevel(): void {
+    this.analyticsManager.Log(AnalyticsEventType.GameOverRestartLevelCTA, {
+      level: this.data?.level,
+    });
     this.data.startOver = false;
     this.dialogRef.close(this.data);
   }

--- a/src/app/game/components/dialogs/components/intro/intro.spec.ts
+++ b/src/app/game/components/dialogs/components/intro/intro.spec.ts
@@ -5,11 +5,13 @@ import { vi } from 'vitest';
 
 import { Intro } from './intro';
 import { SaveGameService } from '../../../../services/save-game/save-game';
+import { AnalyticsEventType, AnalyticsManagerService } from '../../../../../shared/services/analytics-manager';
 
 describe('Intro', () => {
   let component: Intro;
   let fixture: ComponentFixture<Intro>;
   let mockDialogRef: { close: ReturnType<typeof vi.fn> };
+  let analyticsManager: AnalyticsManagerService;
   let mockSaveGameService: {
     HasSaveState: ReturnType<typeof vi.fn>;
     GetSaveState: ReturnType<typeof vi.fn>;
@@ -33,6 +35,9 @@ describe('Intro', () => {
       ],
     }).compileComponents();
 
+    analyticsManager = TestBed.inject(AnalyticsManagerService);
+    vi.spyOn(analyticsManager, 'Log');
+
     fixture = TestBed.createComponent(Intro);
     component = fixture.componentInstance;
     await fixture.whenStable();
@@ -44,21 +49,43 @@ describe('Intro', () => {
     expect(component.savedLevel()).toBe(4);
   });
 
-  it('should close dialog with isContinue: true on ContinueGame', () => {
+  it('should close dialog with isContinue: true and log IntroDialogRestoreCTA on ContinueGame', () => {
     component.ContinueGame();
+    expect(analyticsManager.Log).toHaveBeenCalledWith(
+      AnalyticsEventType.IntroDialogRestoreCTA,
+      expect.objectContaining({ savedLevel: 4 }),
+    );
     expect(mockDialogRef.close).toHaveBeenCalledWith({ isContinue: true });
   });
 
-  it('should prompt confirmation when clicking New Game with active save', () => {
+  it('should prompt confirmation and log IntroDialogNewGameCTA when clicking New Game with active save', () => {
     expect(component.confirmNewGame()).toBe(false);
     component.onNewGameClick();
+    expect(analyticsManager.Log).toHaveBeenCalledWith(
+      AnalyticsEventType.IntroDialogNewGameCTA,
+      expect.objectContaining({ hasRestoreData: true, savedLevel: 4 }),
+    );
     expect(component.confirmNewGame()).toBe(true);
     expect(mockDialogRef.close).not.toHaveBeenCalled();
   });
 
-  it('should clear save state and close dialog on confirmed new game', () => {
+  it('should clear save state and log IntroDialogConfirmNewGameCTA on confirmed new game', () => {
     component.onConfirmNewGame();
+    expect(analyticsManager.Log).toHaveBeenCalledWith(
+      AnalyticsEventType.IntroDialogConfirmNewGameCTA,
+      expect.objectContaining({ previousSavedLevel: 4 }),
+    );
     expect(mockSaveGameService.ClearSaveState).toHaveBeenCalled();
     expect(mockDialogRef.close).toHaveBeenCalledWith({ isContinue: false });
+  });
+
+  it('should log IntroDialogCancelNewGameCTA and reset confirmation on cancel new game', () => {
+    component.confirmNewGame.set(true);
+    component.onCancelNewGame();
+    expect(analyticsManager.Log).toHaveBeenCalledWith(
+      AnalyticsEventType.IntroDialogCancelNewGameCTA,
+      expect.objectContaining({ savedLevel: 4 }),
+    );
+    expect(component.confirmNewGame()).toBe(false);
   });
 });

--- a/src/app/game/components/dialogs/components/intro/intro.ts
+++ b/src/app/game/components/dialogs/components/intro/intro.ts
@@ -79,11 +79,17 @@ export class Intro implements OnInit, OnDestroy {
   }
 
   ContinueGame(): void {
-    this.analyticsManager.Log(AnalyticsEventType.IntroDialogRestoreCTA);
+    this.analyticsManager.Log(AnalyticsEventType.IntroDialogRestoreCTA, {
+      savedLevel: this.savedLevel(),
+    });
     this.dialogRef.close({ isContinue: true });
   }
 
   onNewGameClick(): void {
+    this.analyticsManager.Log(AnalyticsEventType.IntroDialogNewGameCTA, {
+      hasRestoreData: this.hasRestoreData(),
+      savedLevel: this.savedLevel(),
+    });
     if (this.hasRestoreData()) {
       this.confirmNewGame.set(true);
     } else {
@@ -92,11 +98,17 @@ export class Intro implements OnInit, OnDestroy {
   }
 
   onConfirmNewGame(): void {
+    this.analyticsManager.Log(AnalyticsEventType.IntroDialogConfirmNewGameCTA, {
+      previousSavedLevel: this.savedLevel(),
+    });
     this.saveGame.ClearSaveState();
     this.dialogRef.close({ isContinue: false });
   }
 
   onCancelNewGame(): void {
+    this.analyticsManager.Log(AnalyticsEventType.IntroDialogCancelNewGameCTA, {
+      savedLevel: this.savedLevel(),
+    });
     this.confirmNewGame.set(false);
   }
 }

--- a/src/app/game/components/dialogs/components/user-settings/user-settings.spec.ts
+++ b/src/app/game/components/dialogs/components/user-settings/user-settings.spec.ts
@@ -5,11 +5,13 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { HapticsManagerService } from '../../../../../shared/services/haptics-manager';
 import { AudioType } from '../../../../../shared/services/audio/audio-data';
 import { AudioManagerService } from '../../../../../shared/services/audio/audio-manager';
+import { AnalyticsEventType, AnalyticsManagerService } from '../../../../../shared/services/analytics-manager';
 
 describe('UserSettings', () => {
   let component: UserSettings;
   let fixture: ComponentFixture<UserSettings>;
   let hapticsManager: HapticsManagerService;
+  let analyticsManager: AnalyticsManagerService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -22,6 +24,9 @@ describe('UserSettings', () => {
       ],
     }).compileComponents();
 
+    analyticsManager = TestBed.inject(AnalyticsManagerService);
+    vi.spyOn(analyticsManager, 'Log');
+
     fixture = TestBed.createComponent(UserSettings);
     component = fixture.componentInstance;
     hapticsManager = TestBed.inject(HapticsManagerService);
@@ -32,10 +37,11 @@ describe('UserSettings', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should toggle haptics setting via hapticsManager', () => {
+  it('should toggle haptics setting via hapticsManager and log SettingsHapticsChanged', () => {
     const hapticsSpy = vi.spyOn(hapticsManager, 'HapticsEnabled', 'set');
     component.onHapticsChange(false);
     expect(hapticsSpy).toHaveBeenCalledWith(false);
+    expect(analyticsManager.Log).toHaveBeenCalledWith(AnalyticsEventType.SettingsHapticsChanged, { enabled: false });
   });
 
   it('should render disabled toggle and notice when haptic feedback is not available', () => {
@@ -64,7 +70,7 @@ describe('UserSettings', () => {
     expect(playAudioSpy).not.toHaveBeenCalled();
   });
 
-  it('should play AudioType.LEVEL_STAT when game volume selection changes', () => {
+  it('should play AudioType.LEVEL_STAT and log SettingsGameVolumeChanged when game volume changes', () => {
     const audioManager = TestBed.inject(AudioManagerService);
     const setGameVolumeSpy = vi.spyOn(audioManager, 'SetGameVolume');
     const playAudioSpy = vi.spyOn(audioManager, 'PlayAudio');
@@ -75,6 +81,7 @@ describe('UserSettings', () => {
     expect(component.gameVolume()).toBe(80);
     expect(setGameVolumeSpy).toHaveBeenCalledWith(0.8);
     expect(playAudioSpy).toHaveBeenCalledWith(AudioType.LEVEL_STAT);
+    expect(analyticsManager.Log).toHaveBeenCalledWith(AnalyticsEventType.SettingsGameVolumeChanged, { volume: 80 });
   });
 
   it('should update music volume on input without playing audio', () => {
@@ -90,7 +97,7 @@ describe('UserSettings', () => {
     expect(playAudioSpy).not.toHaveBeenCalled();
   });
 
-  it('should play AudioType.LEVEL_END_7 preview on music volume change', () => {
+  it('should play AudioType.LEVEL_END_7 preview and log SettingsMusicVolumeChanged on music volume change', () => {
     const audioManager = TestBed.inject(AudioManagerService);
     const setMusicVolumeSpy = vi.spyOn(audioManager, 'SetMusicVolume');
     const playAudioSpy = vi.spyOn(audioManager, 'PlayAudio');
@@ -103,5 +110,11 @@ describe('UserSettings', () => {
     expect(setMusicVolumeSpy).toHaveBeenCalledWith(0.6);
     expect(stopAudioSpy).toHaveBeenCalledWith(AudioType.LEVEL_END_7);
     expect(playAudioSpy).toHaveBeenCalledWith(AudioType.LEVEL_END_7, false, false, 2.0);
+    expect(analyticsManager.Log).toHaveBeenCalledWith(AnalyticsEventType.SettingsMusicVolumeChanged, { volume: 60 });
+  });
+
+  it('should log SettingsClearHighScores on confirm clear high scores', () => {
+    component.onConfirmClearHighScores();
+    expect(analyticsManager.Log).toHaveBeenCalledWith(AnalyticsEventType.SettingsClearHighScores);
   });
 });

--- a/src/app/game/components/dialogs/components/user-settings/user-settings.ts
+++ b/src/app/game/components/dialogs/components/user-settings/user-settings.ts
@@ -11,6 +11,7 @@ import { AudioManagerService } from '../../../../../shared/services/audio/audio-
 import { HighScoreManagerService } from '../../../../../shared/services/high-score-manager';
 import { StorageService } from '../../../../../shared/services/storage/storage.service';
 import { HapticsManagerService } from '../../../../../shared/services/haptics-manager';
+import { AnalyticsEventType, AnalyticsManagerService } from '../../../../../shared/services/analytics-manager';
 
 @Component({
   selector: 'wgl-user-settings',
@@ -31,6 +32,7 @@ export class UserSettings implements OnDestroy {
   private highScoreManager = inject(HighScoreManagerService);
   private storageService = inject(StorageService);
   private hapticsManager = inject(HapticsManagerService);
+  private analyticsManager = inject(AnalyticsManagerService);
   private dialogRef = inject(MatDialogRef<UserSettings>);
 
   gameVolume = signal<number>(Math.round(this.audioManager.GetGameVolume() * 100));
@@ -49,6 +51,7 @@ export class UserSettings implements OnDestroy {
 
   onHapticsChange(enabled: boolean): void {
     this.hapticsManager.HapticsEnabled = enabled;
+    this.analyticsManager.Log(AnalyticsEventType.SettingsHapticsChanged, { enabled });
   }
 
   onGameVolumeInput(event: Event): void {
@@ -64,6 +67,7 @@ export class UserSettings implements OnDestroy {
     this.gameVolume.set(val);
     this.audioManager.SetGameVolume(val / 100);
     this.audioManager.PlayAudio(AudioType.LEVEL_STAT);
+    this.analyticsManager.Log(AnalyticsEventType.SettingsGameVolumeChanged, { volume: val });
   }
 
   onMusicVolumeInput(event: Event): void {
@@ -88,6 +92,8 @@ export class UserSettings implements OnDestroy {
     this.musicPreviewTimeout = setTimeout(() => {
       this.audioManager.StopAudio(AudioType.LEVEL_END_7);
     }, 2500);
+
+    this.analyticsManager.Log(AnalyticsEventType.SettingsMusicVolumeChanged, { volume: val });
   }
 
   onPromptClearHighScores(): void {
@@ -98,6 +104,7 @@ export class UserSettings implements OnDestroy {
     this.highScoreManager.ClearHighScores();
     this.scoresCleared.set(true);
     this.confirmClear.set(false);
+    this.analyticsManager.Log(AnalyticsEventType.SettingsClearHighScores);
   }
 
   onCancelClearHighScores(): void {
@@ -114,6 +121,7 @@ export class UserSettings implements OnDestroy {
     this.confirmClear.set(false);
     this.confirmFactoryReset.set(false);
     this.factoryResetCompleted.set(true);
+    this.analyticsManager.Log(AnalyticsEventType.SettingsFactoryReset);
 
     setTimeout(() => {
       window.location.reload();

--- a/src/app/game/components/game-container/game-container.spec.ts
+++ b/src/app/game/components/game-container/game-container.spec.ts
@@ -4,6 +4,8 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { vi } from 'vitest';
+
 import { AudioManagerService } from '../../../shared/services/audio/audio-manager';
 import { EffectsManagerService } from '../../services/effects-manager';
 import { GameEngineService } from '../../services/game-engine';
@@ -15,11 +17,14 @@ import { ScoringManagerService } from '../../services/scoring-manager';
 import { ShareManagerService } from '../../services/share-manager';
 import { TextureManagerService } from '../../services/texture/texture-manager';
 import { TextZoom } from '../../text/components/text-zoom/text-zoom';
+import { AnalyticsEventType, AnalyticsManagerService } from '../../../shared/services/analytics-manager';
 import { GameContainer } from './game-container';
 
 describe('GameContainer', () => {
   let component: GameContainer;
   let fixture: ComponentFixture<GameContainer>;
+  let objectManager: ObjectManagerService;
+  let analyticsManager: AnalyticsManagerService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -39,6 +44,10 @@ describe('GameContainer', () => {
         ShareManagerService,
       ],
     }).compileComponents();
+
+    objectManager = TestBed.inject(ObjectManagerService);
+    analyticsManager = TestBed.inject(AnalyticsManagerService);
+    vi.spyOn(analyticsManager, 'Log');
   });
 
   beforeEach(() => {
@@ -56,5 +65,21 @@ describe('GameContainer', () => {
     expect(config.height).toBe('17.5em');
     expect(config.maxHeight).toBe('90dvh');
     expect(config.disableClose).toBe(true);
+  });
+
+  it('should log LevelCompleted when level is completed successfully', () => {
+    objectManager.LevelCompleted.next(false);
+    expect(analyticsManager.Log).toHaveBeenCalledWith(
+      AnalyticsEventType.LevelCompleted,
+      expect.objectContaining({ level: expect.any(Number) }),
+    );
+  });
+
+  it('should log GameOver when game over occurs', () => {
+    objectManager.LevelCompleted.next(true);
+    expect(analyticsManager.Log).toHaveBeenCalledWith(
+      AnalyticsEventType.GameOver,
+      expect.objectContaining({ level: expect.any(Number) }),
+    );
   });
 });

--- a/src/app/game/components/game-container/game-container.ts
+++ b/src/app/game/components/game-container/game-container.ts
@@ -15,6 +15,7 @@ import { HintsManagerService } from '../../services/hints-manager';
 import { PostProcessingManagerService } from '../../services/post-processing-manager';
 import { SaveGameService } from '../../services/save-game/save-game';
 import { ShareManagerService } from '../../services/share-manager';
+import { AnalyticsEventType, AnalyticsManagerService } from '../../../shared/services/analytics-manager';
 import { PRNG } from '../../../shared/utils/prng';
 
 import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
@@ -62,6 +63,7 @@ export class GameContainer implements OnInit, AfterViewInit {
   private postProcessingManager = inject(PostProcessingManagerService);
   private saveGame = inject(SaveGameService);
   private shareManager = inject(ShareManagerService);
+  private analyticsManager = inject(AnalyticsManagerService);
   public scoringManager = inject(ScoringManagerService);
   private document = inject(DOCUMENT);
   private destroyRef = inject(DestroyRef);
@@ -101,6 +103,12 @@ export class GameContainer implements OnInit, AfterViewInit {
       // game state
       this._isGameOver = gameOver;
       if (!this._isGameOver) {
+        this.analyticsManager.Log(AnalyticsEventType.LevelCompleted, {
+          level: this.scoringManager.Level,
+          score: this.scoringManager.Score,
+          movesRemaining: this.scoringManager.PlayerMoves,
+        });
+
         this.scoringManager.IncLevel();
         this._activeLevelSeed = PRNG.generateSeed();
         this._activeRng = new PRNG(this._activeLevelSeed);
@@ -114,6 +122,10 @@ export class GameContainer implements OnInit, AfterViewInit {
           .pipe(take(1))
           .subscribe();
       } else {
+        this.analyticsManager.Log(AnalyticsEventType.GameOver, {
+          level: this.scoringManager.Level,
+          score: this.scoringManager.Score,
+        });
         this.highScoreManager.UpdateHighScores(this.scoringManager.Score);
       }
 
@@ -132,16 +144,17 @@ export class GameContainer implements OnInit, AfterViewInit {
       if (this._isGameOver) {
         // game over
         this._dialogGameOverRef = this.dialog.open(GameOver, this.dialogConfig());
-        this._dialogGameOverRef.afterClosed().subscribe((data: GameOverData) => {
+        this._dialogGameOverRef.afterClosed().subscribe((data?: GameOverData) => {
           this.shareManager.UpdateInLevel(true);
-          if (data.startOver) {
+          const startOver = data?.startOver ?? true;
+          if (startOver) {
             this.saveGame.ClearSaveState();
             this.scoringManager.RestartGame();
             this._activeLevelSeed = PRNG.generateSeed();
             this._activeRng = new PRNG(this._activeLevelSeed);
           } else {
             // reset stats will take care of move count based on level
-            this.scoringManager.ResetStats(!data.startOver);
+            this.scoringManager.ResetStats(!startOver);
             this.saveGame
               .SaveState(
                 this.scoringManager.Level,
@@ -152,6 +165,11 @@ export class GameContainer implements OnInit, AfterViewInit {
               .pipe(take(1))
               .subscribe();
           }
+          this.analyticsManager.Log(AnalyticsEventType.LevelStarted, {
+            level: this.scoringManager.Level,
+            score: this.scoringManager.Score,
+            isRestart: true,
+          });
           this.objectManager.NextLevel(this.scoringManager.Level, true, this._activeRng);
         });
       } else {
@@ -338,9 +356,17 @@ export class GameContainer implements OnInit, AfterViewInit {
     if (this._showWelcome) {
       this._showWelcome = false;
       this.showScoreProgress.set(true);
+      this.analyticsManager.Log(AnalyticsEventType.LevelStarted, {
+        level: this.scoringManager.Level,
+        score: this.scoringManager.Score,
+      });
       this.objectManager.NextLevel(this.scoringManager.Level, true, this._activeRng);
     } else {
       this.scoringManager.NextLevel();
+      this.analyticsManager.Log(AnalyticsEventType.LevelStarted, {
+        level: this.scoringManager.Level,
+        score: this.scoringManager.Score,
+      });
       this.objectManager.NextLevel(this.scoringManager.Level, true, this._activeRng);
     }
   }

--- a/src/app/game/components/game-menu/game-menu.spec.ts
+++ b/src/app/game/components/game-menu/game-menu.spec.ts
@@ -5,10 +5,13 @@ import { vi } from 'vitest';
 
 import { GameMenu } from './game-menu';
 import { InstallPwaDialog } from '../dialogs/components/install-pwa/install-pwa';
+import { UserSettings } from '../dialogs/components/user-settings/user-settings';
+import { AnalyticsEventType, AnalyticsManagerService } from '../../../shared/services/analytics-manager';
 
 describe('GameMenu', () => {
   let component: GameMenu;
   let fixture: ComponentFixture<GameMenu>;
+  let analyticsManager: AnalyticsManagerService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -23,6 +26,9 @@ describe('GameMenu', () => {
       ],
     }).compileComponents();
 
+    analyticsManager = TestBed.inject(AnalyticsManagerService);
+    vi.spyOn(analyticsManager, 'Log');
+
     fixture = TestBed.createComponent(GameMenu);
     component = fixture.componentInstance;
     await fixture.whenStable();
@@ -32,12 +38,31 @@ describe('GameMenu', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should open install pwa dialog when InstallAppClick is called', async () => {
+  it('should log GameMenuAboutCTA when AboutClick is called', () => {
+    component.AboutClick();
+    expect(analyticsManager.Log).toHaveBeenCalledWith(AnalyticsEventType.GameMenuAboutCTA);
+  });
+
+  it('should log GameMenuSettingsCTA and open dialog when SettingsClick is called', () => {
+    const dialog = component['dialog'];
+    const openSpy = vi
+      .spyOn(dialog, 'open')
+      .mockReturnValue({ afterClosed: () => of(true) } as unknown as MatDialogRef<UserSettings>);
+    component.SettingsClick();
+    expect(analyticsManager.Log).toHaveBeenCalledWith(AnalyticsEventType.GameMenuSettingsCTA);
+    expect(openSpy).toHaveBeenCalled();
+  });
+
+  it('should open install pwa dialog and log GameMenuInstallAppCTA when InstallAppClick is called', async () => {
     const dialog = component['dialog'];
     const openSpy = vi
       .spyOn(dialog, 'open')
       .mockReturnValue({ afterClosed: () => of(true) } as unknown as MatDialogRef<InstallPwaDialog>);
     await component.InstallAppClick();
+    expect(analyticsManager.Log).toHaveBeenCalledWith(
+      AnalyticsEventType.GameMenuInstallAppCTA,
+      expect.objectContaining({ canInstall: expect.any(Boolean) }),
+    );
     expect(openSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/game/components/game-menu/game-menu.ts
+++ b/src/app/game/components/game-menu/game-menu.ts
@@ -34,6 +34,7 @@ export class GameMenu {
   }
 
   public SettingsClick(): void {
+    this.analyticsManager.Log(AnalyticsEventType.GameMenuSettingsCTA);
     this.dialog.open(UserSettings, {
       minWidth: '20em',
       panelClass: ['wgl-pane-bounce'],
@@ -41,6 +42,11 @@ export class GameMenu {
   }
 
   public async InstallAppClick(): Promise<void> {
+    this.analyticsManager.Log(AnalyticsEventType.GameMenuInstallAppCTA, {
+      canInstall: this.pwaInstallService.canInstall(),
+      isStandalone: this.pwaInstallService.isStandalone(),
+    });
+
     if (this.pwaInstallService.canInstall()) {
       const result = await this.pwaInstallService.promptInstall();
       if (result === 'accepted') {

--- a/src/app/shared/components/about/about.spec.ts
+++ b/src/app/shared/components/about/about.spec.ts
@@ -1,24 +1,34 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
 
 import { About } from './about';
 import { StoreService } from '../../../app-store/services/store.service';
+import { AnalyticsEventType, AnalyticsManagerService } from '../../services/analytics-manager';
 
 describe('About', () => {
   let component: About;
   let fixture: ComponentFixture<About>;
+  let analyticsManager: AnalyticsManagerService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [About],
     }).compileComponents();
 
+    analyticsManager = TestBed.inject(AnalyticsManagerService);
+    vi.spyOn(analyticsManager, 'Log');
+
     fixture = TestBed.createComponent(About);
     component = fixture.componentInstance;
     await fixture.whenStable();
   });
 
-  it('should create', () => {
+  it('should create and log AboutDialogViewed', () => {
     expect(component).toBeTruthy();
+    expect(analyticsManager.Log).toHaveBeenCalledWith(
+      AnalyticsEventType.AboutDialogViewed,
+      expect.objectContaining({ colorCount: expect.any(Number) }),
+    );
   });
 
   it('should initialize levelColorScheme from StoreService', () => {
@@ -27,5 +37,9 @@ describe('About', () => {
     component.ngOnInit();
     expect(component.levelColorScheme()?.name).toBe('Glassmorphic Purple');
     expect(component.levelColorScheme()?.emoji).toBe('💜');
+    expect(analyticsManager.Log).toHaveBeenCalledWith(
+      AnalyticsEventType.AboutDialogViewed,
+      expect.objectContaining({ colorScheme: 'Glassmorphic Purple' }),
+    );
   });
 });

--- a/src/app/shared/components/about/about.ts
+++ b/src/app/shared/components/about/about.ts
@@ -4,6 +4,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { EmojiInfo } from '../../../app-store/models/emoji-info';
 import { ColorSchemeMeta, StoreService } from '../../../app-store/services/store.service';
+import { AnalyticsEventType, AnalyticsManagerService } from '../../services/analytics-manager';
 
 @Component({
   selector: 'wgl-about',
@@ -13,15 +14,26 @@ import { ColorSchemeMeta, StoreService } from '../../../app-store/services/store
 })
 export class About implements OnInit {
   private store = inject(StoreService);
+  private analyticsManager = inject(AnalyticsManagerService);
 
   levelColors = signal<string[]>([]);
   levelColorScheme = signal<ColorSchemeMeta | undefined>(undefined);
   levelEmojis = signal<EmojiInfo | undefined>(undefined);
 
   ngOnInit(): void {
-    this.levelColors.set(this.store.LevelColors);
-    this.levelColorScheme.set(this.store.LevelColorScheme);
-    this.levelEmojis.set(this.store.EmojiInfo);
+    const colors = this.store.LevelColors;
+    const colorScheme = this.store.LevelColorScheme;
+    const emojiInfo = this.store.EmojiInfo;
+
+    this.levelColors.set(colors);
+    this.levelColorScheme.set(colorScheme);
+    this.levelEmojis.set(emojiInfo);
+
+    this.analyticsManager.Log(AnalyticsEventType.AboutDialogViewed, {
+      colorScheme: colorScheme?.name,
+      colorCount: colors?.length ?? 0,
+      emojiGroup: emojiInfo?.group,
+    });
   }
 }
 

--- a/src/app/shared/services/analytics-manager.spec.ts
+++ b/src/app/shared/services/analytics-manager.spec.ts
@@ -53,6 +53,21 @@ describe('AnalyticsManagerService', () => {
 
     service.Log(AnalyticsEventType.IntroDialogRestoreCTA);
     expect(mixpanel.track).toHaveBeenCalledWith('IntroDialogRestoreCTA', undefined);
+
+    service.Log(AnalyticsEventType.LevelStarted, { level: 1 });
+    expect(mixpanel.track).toHaveBeenCalledWith('LevelStarted', { level: 1 });
+
+    service.Log(AnalyticsEventType.LevelCompleted, { level: 1, score: 500 });
+    expect(mixpanel.track).toHaveBeenCalledWith('LevelCompleted', { level: 1, score: 500 });
+
+    service.Log(AnalyticsEventType.GameOver, { level: 3, score: 1200 });
+    expect(mixpanel.track).toHaveBeenCalledWith('GameOver', { level: 3, score: 1200 });
+
+    service.Log(AnalyticsEventType.AboutDialogViewed, { colorScheme: 'Colors' });
+    expect(mixpanel.track).toHaveBeenCalledWith('AboutDialogViewed', { colorScheme: 'Colors' });
+
+    service.Log(AnalyticsEventType.SettingsHapticsChanged, { enabled: true });
+    expect(mixpanel.track).toHaveBeenCalledWith('SettingsHapticsChanged', { enabled: true });
   });
 
   it('should queue actions until Mixpanel is loaded', async () => {

--- a/src/app/shared/services/analytics-manager.ts
+++ b/src/app/shared/services/analytics-manager.ts
@@ -4,12 +4,49 @@ import type { Dict } from 'mixpanel-browser';
 export const MIXPANEL_TOKEN = '28b44f3bae1356f754ef458b4ae316c6';
 
 export enum AnalyticsEventType {
+  // Share
   ShareCTA = 1000,
+
+  // Game Menu
   GameMenu = 2000,
   GameMenuAboutCTA = 2001,
   GameMenuSaveCTA = 2002,
+  GameMenuSettingsCTA = 2003,
+  GameMenuInstallAppCTA = 2004,
+
+  // Level Complete Dialog
   LevelDialogNextCTA = 3000,
+
+  // Intro Dialog
   IntroDialogRestoreCTA = 4000,
+  IntroDialogNewGameCTA = 4001,
+  IntroDialogConfirmNewGameCTA = 4002,
+  IntroDialogCancelNewGameCTA = 4003,
+
+  // Game Over Dialog
+  GameOverDialogViewed = 5000,
+  GameOverRestartLevelCTA = 5001,
+  GameOverStartOverCTA = 5002,
+  GameOverConfirmStartOverCTA = 5003,
+  GameOverCancelStartOverCTA = 5004,
+
+  // About Dialog
+  AboutDialogViewed = 6000,
+
+  // Game Lifecycle
+  LevelStarted = 7000,
+  LevelCompleted = 7001,
+  GameOver = 7002,
+
+  // Settings
+  SettingsHapticsChanged = 8000,
+  SettingsGameVolumeChanged = 8001,
+  SettingsMusicVolumeChanged = 8002,
+  SettingsClearHighScores = 8003,
+  SettingsFactoryReset = 8004,
+
+  // PWA
+  PwaInstallPromptOutcome = 9000,
 }
 
 type MixpanelInstance = typeof import('mixpanel-browser').default;

--- a/src/app/shared/services/pwa-install.spec.ts
+++ b/src/app/shared/services/pwa-install.spec.ts
@@ -1,15 +1,42 @@
 import { TestBed } from '@angular/core/testing';
-import { PwaInstallService } from './pwa-install';
+import { vi } from 'vitest';
+import { BeforeInstallPromptEvent, PwaInstallService } from './pwa-install';
+import { AnalyticsEventType, AnalyticsManagerService } from './analytics-manager';
 
 describe('PwaInstallService', () => {
   let service: PwaInstallService;
+  let analyticsManager: AnalyticsManagerService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
+    analyticsManager = TestBed.inject(AnalyticsManagerService);
+    vi.spyOn(analyticsManager, 'Log');
     service = TestBed.inject(PwaInstallService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should return unavailable when no deferredPrompt is present', async () => {
+    const outcome = await service.promptInstall();
+    expect(outcome).toBe('unavailable');
+    expect(analyticsManager.Log).not.toHaveBeenCalled();
+  });
+
+  it('should log PwaInstallPromptOutcome when prompt resolves', async () => {
+    const mockPromptEvent: Partial<BeforeInstallPromptEvent> = {
+      prompt: vi.fn().mockResolvedValue(undefined),
+      userChoice: Promise.resolve({ outcome: 'accepted' as const, platform: 'web' }),
+    };
+
+    service['deferredPrompt'] = mockPromptEvent as unknown as BeforeInstallPromptEvent;
+    service.canInstall.set(true);
+
+    const outcome = await service.promptInstall();
+    expect(outcome).toBe('accepted');
+    expect(analyticsManager.Log).toHaveBeenCalledWith(AnalyticsEventType.PwaInstallPromptOutcome, {
+      outcome: 'accepted',
+    });
   });
 });

--- a/src/app/shared/services/pwa-install.ts
+++ b/src/app/shared/services/pwa-install.ts
@@ -1,4 +1,5 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
+import { AnalyticsEventType, AnalyticsManagerService } from './analytics-manager';
 
 export interface BeforeInstallPromptEvent extends Event {
   readonly platforms: string[];
@@ -14,6 +15,7 @@ export interface BeforeInstallPromptEvent extends Event {
 })
 export class PwaInstallService {
   private deferredPrompt: BeforeInstallPromptEvent | null = null;
+  private analyticsManager = inject(AnalyticsManagerService);
 
   public canInstall = signal<boolean>(false);
   public isStandalone = signal<boolean>(false);
@@ -122,7 +124,9 @@ export class PwaInstallService {
         }
         this.canInstall.set(false);
 
-        return choiceResult?.outcome === 'accepted' ? 'accepted' : 'dismissed';
+        const outcome = choiceResult?.outcome === 'accepted' ? 'accepted' : 'dismissed';
+        this.analyticsManager.Log(AnalyticsEventType.PwaInstallPromptOutcome, { outcome });
+        return outcome;
       } catch (error) {
         attempt++;
         if (attempt > maxRetries) {

--- a/src/app/version.ts
+++ b/src/app/version.ts
@@ -1,2 +1,2 @@
 // Generated automatically during build
-export const APP_VERSION = 'v2026.08.16.1408';
+export const APP_VERSION = 'v2026.08.17.1708';


### PR DESCRIPTION
   ## Summary
    Adds comprehensive Mixpanel telemetry across core gameplay loops, navigation menus, dialog interactions,
  user settings, and PWA prompts.

    ## Key Changes
    - **Intro Dialog**: Tagged `IntroDialogRestoreCTA`, `IntroDialogNewGameCTA`,
  `IntroDialogConfirmNewGameCTA`, and `IntroDialogCancelNewGameCTA`.
    - **Game Over Dialog**: Tagged `GameOverDialogViewed`, `GameOverRestartLevelCTA`,
  `GameOverStartOverCTA`, `GameOverConfirmStartOverCTA`, and `GameOverCancelStartOverCTA`.
    - **About Dialog**: Tagged `AboutDialogViewed` with color scheme and emoji metadata.
    - **Game Menu**: Tagged `GameMenuSettingsCTA` and `GameMenuInstallAppCTA`.
    - **Game Loop**: Tagged `LevelStarted`, `LevelCompleted`, and `GameOver` with level, score, and moves
  telemetry in `GameContainer`.
    - **Settings**: Tagged audio volume adjustments, haptic toggles, high score resets, and factory resets
  in `UserSettings`.
    - **PWA**: Tagged native install prompt outcomes (`accepted` | `dismissed`).
    - **Tests**: Added/updated unit tests with full mock coverage across all modified components and
  services.